### PR TITLE
Metadata DB existing run_hash

### DIFF
--- a/src/bespokelabs/curator/db.py
+++ b/src/bespokelabs/curator/db.py
@@ -15,6 +15,7 @@ class MetadataDB:
         
         Args:
             metadata: Dictionary containing run metadata with keys:
+                - timestamp: ISO format timestamp
                 - dataset_hash: Unique hash of input dataset
                 - prompt_func: Source code of prompt function
                 - model_name: Name of model used


### PR DESCRIPTION
if fingerprint already exist, don't create a duplicate metadata entry update last edit time

Changes: 
- Make run_hash the primary key
- del `timestamp` column
- add `created_time` and `last_edited_time`

In the UI, it would look like the following
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/3ad3bdff-a643-42c7-ac10-fa04f5e56e16">
