### PR TITLE
Fix broken pytest

### DIFF
--- a/src/bespokelabs/curator/dataset.py
+++ b/src/bespokelabs/curator/dataset.py
@@ -107,6 +107,8 @@ class Dataset:
                             dataset_rows = [response.response]
 
                         for row in dataset_rows:
+                            if isinstance(row, BaseModel):
+                                row = row.model_dump()
                             # NOTE(Ryan): This throws a strange error if there are null values in the row
                             writer.write(row)
 


### PR DESCRIPTION
The pytest we had was broken since it used the old interface.

While fixing this test, I found another issue: ArrowWriter does not work with BaseModel, so if a row is a BaseModel, we have to dump it to json before writing.