### PR TITLE
[Hot fix] Fixed file path for batch=False prompter requests

### DIFF
--- a/bespoke-dataset-viewer/app/api/responses/[runHash]/route.ts
+++ b/bespoke-dataset-viewer/app/api/responses/[runHash]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
 ): Promise<Response> {  // This is the key change
   try {
     const { runHash } = await params
-    const responsesPath = join(homedir(), '.cache', 'curator', runHash, 'responses.jsonl')
+    const responsesPath = join(homedir(), '.cache', 'curator', runHash, 'responses_0.jsonl')
     
     const searchParams = request.nextUrl.searchParams
     const lastLineNumber = parseInt(searchParams.get('lastLine') || '0')


### PR DESCRIPTION
#28 introduces a new cache storing logic, causing frontend cache loading behaviors to change. 

In this PR, addresses for #45 

For `batch=False` requests, there's a rename to the `responses.jsonl` -> `responses_0.jsonl` with the same streaming logic (check for lastline). 

**The data viewer is expected to behave normally after this PR for all `batch=False` requests, including `examples/poem.py` and `examples/camel.py`.** 

Here is a quick fix for #45, there will be a separate PR that deals with batch=True requests, in which a separate streaming logic will be implemented that address #46 