### PR TITLE
Alow specifiying working directory in case users want to use a different working directory for their cache

### DIFF
--- a/src/bespokelabs/curator/prompter/prompter.py
+++ b/src/bespokelabs/curator/prompter/prompter.py
@@ -22,6 +22,7 @@ from bespokelabs.curator.request_processor.openai_online_request_processor impor
     OpenAIOnlineRequestProcessor,
 )
 
+_CURATOR_DEFAULT_CACHE_DIR = "~/.cache/curator"
 T = TypeVar("T")
 
 
@@ -113,7 +114,7 @@ class Prompter:
 
         if working_dir is None:
             curator_cache_dir = os.environ.get(
-                "CURATOR_CACHE_DIR", os.path.expanduser("~/.cache/curator")
+                "CURATOR_CACHE_DIR", os.path.expanduser(_CURATOR_DEFAULT_CACHE_DIR)
             )
         else:
             curator_cache_dir = working_dir


### PR DESCRIPTION
DCFT has a concrete need where separate outputs from different operators need to be stored in different cache directories.

I also feel like this would be a useful feature for users generally (huggingface datasets has a similar way of specifying file names in https://huggingface.co/docs/datasets/v3.1.0/en/package_reference/main_classes#datasets.Dataset.map.cache_file_name)


