### PR TITLE
Add batch_mode as a field in metadata db

### DIFF
--- a/src/bespokelabs/curator/db.py
+++ b/src/bespokelabs/curator/db.py
@@ -21,6 +21,7 @@ class MetadataDB:
                 - model_name: Name of model used
                 - response_format: JSON schema of response format
                 - run_hash: Unique hash identifying the run
+                - batch_mode: Boolean indicating batch mode or online mode (True = batch, False = online)
         """
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
         with sqlite3.connect(self.db_path) as conn:
@@ -33,6 +34,7 @@ class MetadataDB:
                     prompt_func TEXT,
                     model_name TEXT,
                     response_format TEXT,
+                    batch_mode BOOLEAN,
                     created_time TEXT,
                     last_edited_time TEXT
                 )
@@ -61,8 +63,8 @@ class MetadataDB:
                     """
                     INSERT INTO runs (
                         run_hash, dataset_hash, prompt_func, model_name, 
-                        response_format, created_time, last_edited_time
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        response_format, batch_mode, created_time, last_edited_time
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         metadata["run_hash"],
@@ -70,6 +72,7 @@ class MetadataDB:
                         metadata["prompt_func"],
                         metadata["model_name"],
                         metadata["response_format"],
+                        metadata["batch_mode"],
                         metadata["timestamp"],
                         "-",
                     ),

--- a/src/bespokelabs/curator/prompter/prompter.py
+++ b/src/bespokelabs/curator/prompter/prompter.py
@@ -67,7 +67,7 @@ class Prompter:
         self.prompt_formatter = PromptFormatter(
             model_name, prompt_func, parse_func, response_format
         )
-
+        self.batch_mode = batch
         if batch:
             self._request_processor = OpenAIBatchRequestProcessor(model=model_name)
         else:
@@ -126,6 +126,7 @@ class Prompter:
                     if self.prompt_formatter.response_format
                     else "text"
                 ),
+                str(self.batch_mode),
             ]
         )
 
@@ -152,6 +153,7 @@ class Prompter:
                 else "text"
             ),
             "run_hash": fingerprint,
+            "batch_mode": self.batch_mode,
         }
         metadata_db.store_metadata(metadata_dict)
 


### PR DESCRIPTION
Changes: 
- Add `batch_mode` as a field in `metadata.db` signaling streaming strategy in frontend to choose from. 
- Make `batch_mode` as part of fingerprint, since the resume logic is different for `batch=False` and `batch=True` and would require unique fingerprint for different batch_mode. 

A step for frontend streaming logic supporting `batch=True`. 