### PR TITLE
Remove the use of asyncio.run to make asyncio work in colab

### DIFF
--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -13,9 +13,13 @@ from datasets.arrow_writer import ArrowWriter, SchemaInferenceError
 from pydantic import BaseModel
 
 from bespokelabs.curator.prompter.prompt_formatter import PromptFormatter
-from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
+from bespokelabs.curator.request_processor.event_loop import (
+    get_or_create_event_loop,
+)
 from bespokelabs.curator.request_processor.generic_request import GenericRequest
-from bespokelabs.curator.request_processor.generic_response import GenericResponse
+from bespokelabs.curator.request_processor.generic_response import (
+    GenericResponse,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -13,6 +13,7 @@ from datasets.arrow_writer import ArrowWriter, SchemaInferenceError
 from pydantic import BaseModel
 
 from bespokelabs.curator.prompter.prompt_formatter import PromptFormatter
+from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
 from bespokelabs.curator.request_processor.generic_request import GenericRequest
 from bespokelabs.curator.request_processor.generic_response import GenericResponse
 
@@ -161,9 +162,11 @@ class BaseRequestProcessor(ABC):
                 ]
                 await asyncio.gather(*tasks)
 
-            asyncio.run(create_all_request_files())
+            loop = get_or_create_event_loop()
+            loop.run_until_complete(create_all_request_files())
         else:
-            asyncio.run(
+            loop = get_or_create_event_loop()
+            loop.run_until_complete(
                 self.acreate_request_file(dataset, prompt_formatter, requests_file)
             )
 

--- a/src/bespokelabs/curator/request_processor/event_loop.py
+++ b/src/bespokelabs/curator/request_processor/event_loop.py
@@ -1,0 +1,16 @@
+import asyncio
+
+
+def get_or_create_event_loop():
+    """
+    Get the current event loop or create a new one if there isn't one.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError as e:
+        # If no event loop is running, asyncio will
+        # return a RuntimeError (https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop).
+        # In that case, we can create a new event loop.
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -15,7 +15,9 @@ from bespokelabs.curator.request_processor.base_request_processor import (
     GenericRequest,
     GenericResponse,
 )
-from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
+from bespokelabs.curator.request_processor.event_loop import (
+    get_or_create_event_loop,
+)
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
@@ -260,7 +262,9 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
 
         loop = get_or_create_event_loop()
         loop.run_until_complete(
-            batch_watcher.watch(prompt_formatter, self.get_generic_response, dataset)
+            batch_watcher.watch(
+                prompt_formatter, self.get_generic_response, dataset
+            )
         )
 
         dataset = self.create_dataset_files(

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -3,16 +3,19 @@ import json
 import logging
 import os
 from typing import Callable, Dict, Optional, TypeVar
-from openai import AsyncOpenAI
+
 import aiofiles
+from openai import AsyncOpenAI
+from tqdm import tqdm
+
 from bespokelabs.curator.dataset import Dataset
+from bespokelabs.curator.prompter.prompt_formatter import PromptFormatter
 from bespokelabs.curator.request_processor.base_request_processor import (
     BaseRequestProcessor,
     GenericRequest,
     GenericResponse,
 )
-from bespokelabs.curator.prompter.prompt_formatter import PromptFormatter
-from tqdm import tqdm
+from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
@@ -243,7 +246,8 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
         # TODO(Ryan): likely can add some logic for smarter check_interval based on batch size and if the batch has started or not, fine to do a dumb ping for now
         batch_watcher = BatchWatcher(working_dir, check_interval=self.check_interval)
 
-        asyncio.run(
+        loop = get_or_create_event_loop()
+        loop.run_until_complete(
             batch_watcher.watch(prompt_formatter, self.get_generic_response, dataset)
         )
 

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -20,7 +20,9 @@ from bespokelabs.curator.request_processor.base_request_processor import (
     GenericRequest,
     GenericResponse,
 )
-from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
+from bespokelabs.curator.request_processor.event_loop import (
+    get_or_create_event_loop,
+)
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -20,6 +20,7 @@ from bespokelabs.curator.request_processor.base_request_processor import (
     GenericRequest,
     GenericResponse,
 )
+from bespokelabs.curator.request_processor.event_loop import get_or_create_event_loop
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -5,21 +5,21 @@ import os
 import re
 import time
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Callable, Dict, Optional, Set, Tuple, TypeVar
 
 import aiohttp
 import requests
 import tiktoken
 from tqdm import tqdm
-from functools import partial
 
 from bespokelabs.curator.dataset import Dataset
+from bespokelabs.curator.prompter.prompter import PromptFormatter
 from bespokelabs.curator.request_processor.base_request_processor import (
     BaseRequestProcessor,
     GenericRequest,
     GenericResponse,
 )
-from bespokelabs.curator.prompter.prompter import PromptFormatter
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
@@ -187,7 +187,8 @@ class OpenAIOnlineRequestProcessor(BaseRequestProcessor):
         for requests_file, responses_file in zip(
             requests_files, responses_files
         ):
-            asyncio.run(
+            loop = get_or_create_event_loop()
+            loop.run_until_complete(
                 self.process_api_requests_from_file(
                     requests_filepath=requests_file,
                     save_filepath=responses_file,


### PR DESCRIPTION
We're using asyncio.run in our processor, but this will fail in colab where there is a loop already running since asyncio.run creates a new asyncio loop.

What we need to do is first checking if there are any running loops and use that loop instead. If a loop doesn't already exist, we create it.

Closes #68 