### PR TITLE
Set RLIMIT_NOFILE to avoid "too many files open" errors

### DIFF
--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -6,6 +6,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Set, Tuple, TypeVar
+import resource
 
 import aiohttp
 import requests
@@ -163,6 +164,12 @@ class OpenAIOnlineRequestProcessor(BaseRequestProcessor):
         Returns:
             Dataset: Completed dataset
         """
+        # Increase the number of open file descriptors to avoid "Too many open files" errors
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        resource.setrlimit(
+            resource.RLIMIT_NOFILE, (min(hard, 10 * max_requests_per_minute), hard)
+        )
+
         requests_files = self.create_request_files(
             dataset, working_dir, prompt_formatter
         )

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -164,12 +164,6 @@ class OpenAIOnlineRequestProcessor(BaseRequestProcessor):
         Returns:
             Dataset: Completed dataset
         """
-        # Increase the number of open file descriptors to avoid "Too many open files" errors
-        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-        resource.setrlimit(
-            resource.RLIMIT_NOFILE, (min(hard, 10 * max_requests_per_minute), hard)
-        )
-
         requests_files = self.create_request_files(
             dataset, working_dir, prompt_formatter
         )
@@ -218,6 +212,13 @@ class OpenAIOnlineRequestProcessor(BaseRequestProcessor):
         resume_no_retry: bool = False,
     ) -> None:
         """Processes API requests in parallel, throttling to stay under rate limits."""
+
+        # Increase the number of open file descriptors to avoid "Too many open files" errors
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        resource.setrlimit(
+            resource.RLIMIT_NOFILE, (min(hard, 10 * max_requests_per_minute), hard)
+        )
+
         # constants
         seconds_to_pause_after_rate_limit_error = 15
         seconds_to_sleep_each_loop = (


### PR DESCRIPTION
Sending thousands of requests in parallel from a single machine sometimes hits the soft resource limit for number open files.
This change increases this limit enough to accommodate the Prompter job.  