### PR TITLE
Explicitly close AsyncClient to avoid getting asyncio event loop is closed issues

### DIFF
--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -168,7 +168,7 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
         # Explicitly close the client. Otherwise we get something like
         # future: <Task finished name='Task-46' coro=<AsyncClient.aclose() done ... >>
         await async_client.close()
-        
+
         return batch_object
 
     def run(
@@ -241,7 +241,6 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
             # Explicitly close the client. Otherwise we get something like
             # future: <Task finished name='Task-46' coro=<AsyncClient.aclose() done ... >>
             await batch_watcher.close_client()
-
 
         run_in_event_loop(watch_batches())
 


### PR DESCRIPTION
We're getting these errors

```
future: <Task finished name='Task-46' coro=<AsyncClient.aclose() done, defined at /home/trung/.cache/pypoetry/virtualenvs/bespokelabs-curator-H3Ru9elj-py3.11/lib/python3.11/site-packages/httpx/_client.py:2024> exception=RuntimeError('Event loop is closed')>
```

The reason is batch client is creating AsyncClients without explicitly closing them.