### PR TITLE
Prevent batches larger than 200MB from being sent

### DIFF
--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -22,7 +22,7 @@ from bespokelabs.curator.request_processor.event_loop import run_in_event_loop
 logger = logging.getLogger(__name__)
 
 MAX_REQUESTS_PER_BATCH = 50_000
-MAX_BYTES_PER_BATCH = 200_000_000
+MAX_BYTES_PER_BATCH = 200 * 1024 * 1024
 
 
 class OpenAIBatchRequestProcessor(BaseRequestProcessor):

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -22,6 +22,7 @@ from bespokelabs.curator.request_processor.event_loop import run_in_event_loop
 logger = logging.getLogger(__name__)
 
 MAX_REQUESTS_PER_BATCH = 50_000
+MAX_BYTES_PER_BATCH = 200_000_000
 
 
 class OpenAIBatchRequestProcessor(BaseRequestProcessor):
@@ -145,16 +146,36 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
         # Create a list to store API-specific requests
         api_specific_requests = []
 
+        line_count = 0
         async with aiofiles.open(batch_file, "r") as file:
             file_content = await file.read()
             for line in file_content.splitlines():
                 request = GenericRequest.model_validate_json(line)
                 api_specific_request = self.create_api_specific_request(request)
                 api_specific_requests.append(json.dumps(api_specific_request))
+                line_count += 1
+
+        if line_count > MAX_REQUESTS_PER_BATCH:
+            raise ValueError(
+                f"Batch file {batch_file} contains {line_count:,} requests, "
+                f"which is more than the maximum of {MAX_REQUESTS_PER_BATCH:,} requests per batch that OpenAI supports. "
+                f"Preventing batch submission."
+            )
 
         # Join requests with newlines and encode to bytes for upload
         file_content = "\n".join(api_specific_requests).encode()
+        file_content_size = len(file_content)
+        logger.debug(
+            f"Batch file content size: {file_content_size / (1024*1024):.2f} MB ({file_content_size:,} bytes)"
+        )
+        if file_content_size > MAX_BYTES_PER_BATCH:
+            raise ValueError(
+                f"Batch file content size {file_content_size:,} bytes "
+                f"is greater than the maximum of {MAX_BYTES_PER_BATCH:,} bytes per batch that OpenAI supports. "
+                f"Please reduce your batch size or request content size (via prompt_func and response_format)."
+            )
 
+        # this let's you upload a file that is larger than 200MB and won't error, so we catch it above
         batch_file_upload = await async_client.files.create(
             file=file_content, purpose="batch"
         )


### PR DESCRIPTION
# Add OpenAI Batch File Size Validation

## Problem
The OpenAI batch processing API has two key constraints:
1. Maximum 50,000 requests per batch (already enforced)
2. Maximum 200MB file size per batch (previously unenforced)

Without validation for the file size limit, users could encounter cryptic OpenAI API errors and would have the manually touch the files
```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'File is too large.', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

## Solution
- Added `MAX_BYTES_PER_BATCH` constant (200,000,000 bytes)
- Implemented file size validation before batch submission
- Added detailed error messages to help users understand and resolve the issue
- Added debug logging for batch file size

## Context
While this issue is less likely with the default batch size of 1,000 requests, it can still occur when:
- Users manually increase the batch size
- Requests contain large prompts
- Response formats are verbose

The issue was discovered when processing cached requests that exceeded both the 50,000 request limit and 200MB size limit. Clearing the cache resolved the immediate problem, but this validation prevents similar issues in the future.

## References
- [OpenAI Batch Processing Overview](https://platform.openai.com/docs/guides/batch/overview)
- [OpenAI Batch API Reference](https://platform.openai.com/docs/api-reference/batch/create)

Closes #111