### PR TITLE
[curator-viewer] add time logging and curator viewer show distribution

### DIFF
--- a/bespoke-dataset-viewer/app/globals.css
+++ b/bespoke-dataset-viewer/app/globals.css
@@ -37,7 +37,6 @@ body {
     --tooltip-bg: white;
     --tooltip-text-bg: rgb(255, 255, 255);
     --tooltip-text: black;
-    --border: #ccc;
   }
   .dark {
     --background: 0 0% 3.9%;

--- a/bespoke-dataset-viewer/app/globals.css
+++ b/bespoke-dataset-viewer/app/globals.css
@@ -34,6 +34,10 @@ body {
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
     --success: 142 40% 75%;
+    --tooltip-bg: white;
+    --tooltip-text-bg: black;
+    --tooltip-text: black;
+    --border: #ccc;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -61,6 +65,10 @@ body {
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
     --success: 142 72% 40%; /* Slightly brighter green for dark mode */
+    --tooltip-bg: rgb(90, 90, 90);
+    --tooltip-text-bg: rgb(0, 0, 0);
+    --tooltip-text: rgb(250, 250, 250);
+    --border: rgb(39, 39, 42);
   }
 }
 

--- a/bespoke-dataset-viewer/app/globals.css
+++ b/bespoke-dataset-viewer/app/globals.css
@@ -35,7 +35,7 @@ body {
     --radius: 0.5rem;
     --success: 142 40% 75%;
     --tooltip-bg: white;
-    --tooltip-text-bg: black;
+    --tooltip-text-bg: rgb(255, 255, 255);
     --tooltip-text: black;
     --border: #ccc;
   }

--- a/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
@@ -245,7 +245,7 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
                       None
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => setSelectedDistribution("requests")}>
-                      Requests
+                      Requests & Responses
                     </DropdownMenuItem>
                     {["total_tokens", "prompt_tokens", "completion_tokens", "generation_time"].map((column) => (
                       <DropdownMenuItem key={column} onClick={() => setSelectedDistribution(column)}>

--- a/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
@@ -23,7 +23,8 @@ const COLUMNS: Column[] = [
   { key: "user_message", label: "User Message" },
   { key: "assistant_message", label: "Assistant Message" },
   { key: "prompt_tokens", label: "Prompt Tokens" },
-  { key: "completion_tokens", label: "Completion Tokens" }
+  { key: "completion_tokens", label: "Completion Tokens" },
+  { key: "generation_time", label: "Generation Time (s)" }
 ]
 
 interface DatasetViewerProps {
@@ -238,11 +239,12 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
                   <DropdownMenuItem onClick={() => setSelectedDistribution(null)}>
                     None
                   </DropdownMenuItem>
-                  {["total_tokens", "prompt_tokens", "completion_tokens"].map((column) => (
+                  {["total_tokens", "prompt_tokens", "completion_tokens", "generation_time"].map((column) => (
                     <DropdownMenuItem key={column} onClick={() => setSelectedDistribution(column)}>
                       {column === "total_tokens" ? "Total Tokens" :
                         column === "prompt_tokens" ? "Prompt Tokens" :
-                          "Completion Tokens"}
+                          column === "completion_tokens" ? "Completion Tokens" :
+                            "Generation Time (s)"}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>

--- a/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
@@ -63,7 +63,7 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
   const [data, setData] = useState<DataItem[]>([])
   const [theme, setTheme] = useState<"light" | "dark">("light")
   const [mounted, setMounted] = useState(false)
-  const [selectedDistribution, setSelectedDistribution] = useState<string | null>("total_tokens")
+  const [selectedDistribution, setSelectedDistribution] = useState<string | null>("requests")
   const [selectedItem, setSelectedItem] = useState<DataItem | null>(null)
   const { toast } = useToast()
   const [isPolling, setIsPolling] = useState(false)
@@ -233,7 +233,7 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
                     <Button variant="outline">
                       {selectedDistribution
                         ? selectedDistribution === "requests" 
-                          ? "Requests"
+                          ? "Requests & Responses"
                           : selectedDistribution.split('_').map(word =>
                               word.charAt(0).toUpperCase() + word.slice(1)
                             ).join(' ')

--- a/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
@@ -18,6 +18,7 @@ import { FileText, Loader2, RefreshCcw } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { DetailsSidebar } from "./DetailsSidebar"
 import { DistributionChart } from "./DistributionChart"
+import { TimeSeriesChart } from './TimeSeriesChart'
 
 const COLUMNS: Column[] = [
   { key: "user_message", label: "User Message" },
@@ -70,6 +71,7 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const [newItemIds, setNewItemIds] = useState<Set<number>>(new Set())
   const [processedFiles, setProcessedFiles] = useState<string[]>([])
+  const [chartType, setChartType] = useState<'distribution' | 'timeseries' | null>('distribution');
 
   useEffect(() => {
     const systemPreference = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
@@ -225,30 +227,37 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
               <p className="text-sm text-muted-foreground">View and analyze your dataset responses</p>
             </div>
             {data.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline">
-                    {selectedDistribution
-                      ? selectedDistribution.split('_').map(word =>
-                        word.charAt(0).toUpperCase() + word.slice(1)
-                      ).join(' ')
-                      : 'Select Metric'}
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => setSelectedDistribution(null)}>
-                    None
-                  </DropdownMenuItem>
-                  {["total_tokens", "prompt_tokens", "completion_tokens", "generation_time"].map((column) => (
-                    <DropdownMenuItem key={column} onClick={() => setSelectedDistribution(column)}>
-                      {column === "total_tokens" ? "Total Tokens" :
-                        column === "prompt_tokens" ? "Prompt Tokens" :
-                          column === "completion_tokens" ? "Completion Tokens" :
-                            "Generation Time (s)"}
+              <div className="flex gap-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline">
+                      {selectedDistribution
+                        ? selectedDistribution === "requests" 
+                          ? "Requests"
+                          : selectedDistribution.split('_').map(word =>
+                              word.charAt(0).toUpperCase() + word.slice(1)
+                            ).join(' ')
+                        : 'Select Metric'}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => setSelectedDistribution(null)}>
+                      None
                     </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <DropdownMenuItem onClick={() => setSelectedDistribution("requests")}>
+                      Requests
+                    </DropdownMenuItem>
+                    {["total_tokens", "prompt_tokens", "completion_tokens", "generation_time"].map((column) => (
+                      <DropdownMenuItem key={column} onClick={() => setSelectedDistribution(column)}>
+                        {column === "total_tokens" ? "Total Tokens" :
+                          column === "prompt_tokens" ? "Prompt Tokens" :
+                            column === "completion_tokens" ? "Completion Tokens" :
+                              "Generation Time (s)"}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             )}
           </div>
 
@@ -266,10 +275,14 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
               <div className="mb-8 space-y-4">
                 {selectedDistribution && (
                   <div className="rounded-lg border bg-card p-4">
-                    <DistributionChart
-                      data={data}
-                      column={selectedDistribution}
-                    />
+                    {selectedDistribution === "requests" ? (
+                      <TimeSeriesChart data={data} />
+                    ) : (
+                      <DistributionChart
+                        data={data}
+                        column={selectedDistribution}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DatasetViewer.tsx
@@ -71,7 +71,6 @@ export function DatasetViewer({ runHash, batchMode }: DatasetViewerProps) {
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const [newItemIds, setNewItemIds] = useState<Set<number>>(new Set())
   const [processedFiles, setProcessedFiles] = useState<string[]>([])
-  const [chartType, setChartType] = useState<'distribution' | 'timeseries' | null>('distribution');
 
   useEffect(() => {
     const systemPreference = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'

--- a/bespoke-dataset-viewer/components/dataset-viewer/DetailsSidebar.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DetailsSidebar.tsx
@@ -120,6 +120,13 @@ export function DetailsSidebar({ item, onClose }: DetailsSidebarProps) {
                   </div>
                 </div>
               </div>
+              <Separator />
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold">Generation Time</h3>
+                <p className="text-2xl font-bold">
+                  {((new Date(item.finished_at).getTime() - new Date(item.created_at).getTime()) / 1000).toFixed(2)}s
+                </p>
+              </div>
             </CardContent>
           </div>
         </div>

--- a/bespoke-dataset-viewer/components/dataset-viewer/DistributionChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DistributionChart.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { bin } from 'd3-array'
 import { DataItem } from '@/types/dataset'
 
 interface DistributionChartProps {
@@ -11,43 +12,8 @@ interface DistributionChartProps {
 const COLUMN_DISPLAY_NAMES: Record<string, string> = {
   total_tokens: "Total Tokens",
   prompt_tokens: "Prompt Tokens",
-  completion_tokens: "Completion Tokens"
-}
-
-function calculateNiceBinSize(min: number, max: number): { binSize: number, start: number, end: number } {
-  // Calculate the range
-  const range = max - min;
-  
-  // Get the magnitude of the range (in powers of 10)
-  const magnitude = Math.floor(Math.log10(range));
-  
-  // Possible bin sizes (1, 2, 5, 10) * 10^n
-  const base = Math.pow(10, magnitude);
-  const possibleBinSizes = [
-    0.1 * base,
-    0.2 * base,
-    0.5 * base,
-    base,
-    2 * base,
-    5 * base,
-    10 * base
-  ];
-
-  // Aim for between 5-10 bins
-  const targetBins = 7;
-  
-  // Find the bin size that gives us closest to our target number of bins
-  const binSize = possibleBinSizes.reduce((prev, curr) => {
-    const prevBins = range / prev;
-    const currBins = range / curr;
-    return Math.abs(currBins - targetBins) < Math.abs(prevBins - targetBins) ? curr : prev;
-  });
-
-  // Calculate nice start and end points
-  const start = Math.floor(min / binSize) * binSize;
-  const end = Math.ceil(max / binSize) * binSize;
-
-  return { binSize, start, end };
+  completion_tokens: "Completion Tokens",
+  generation_time: "Generation Time (s)"
 }
 
 function getDistributionData(data: DataItem[], column: string) {
@@ -59,53 +25,25 @@ function getDistributionData(data: DataItem[], column: string) {
         return item.raw_response.usage?.prompt_tokens || item.raw_response.response?.body?.usage?.prompt_tokens || 0;
       case "completion_tokens":
         return item.raw_response.usage?.completion_tokens || item.raw_response.response?.body?.usage?.completion_tokens || 0;
+      case "generation_time":
+        return (new Date(item.finished_at).getTime() - new Date(item.created_at).getTime()) / 1000;
       default:
         return 0;
     }
   });
 
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const binner = bin()
+    .value(d => d)
+    .thresholds(10);
 
-  // If min equals max, all values are the same
-  if (min === max) {
-    return [{
-      range: `${min}`,
-      count: values.length
-    }];
-  }
+  const bins = binner(values);
 
-  const { binSize, start, end } = calculateNiceBinSize(min, max);
-  const numBins = Math.ceil((end - start) / binSize);
-  
-  // Initialize buckets
-  const buckets: { range: string; start: number; count: number }[] = [];
-  for (let i = 0; i < numBins; i++) {
-    const bucketStart = start + (i * binSize);
-    const bucketEnd = bucketStart + binSize;
-    buckets.push({
-      range: `${Math.round(bucketStart)}-${Math.round(bucketEnd)}`,
-      start: bucketStart,
-      count: 0
-    });
-  }
-
-  // Count values in buckets
-  values.forEach(value => {
-    const bucketIndex = Math.floor((value - start) / binSize);
-    if (bucketIndex >= 0 && bucketIndex < buckets.length) {
-      buckets[bucketIndex].count++;
-    }
-  });
-
-  // Only return buckets that have counts
-  return buckets
-    .filter(bucket => bucket.count > 0)
-    .sort((a, b) => a.start - b.start)
-    .map(({ range, count }) => ({
-      range,
-      count
-    }));
+  return bins.map(b => ({
+    range: Number.isInteger(b.x0) ? `${b.x0}` : `${b.x0?.toFixed(2)}`,
+    count: b.length,
+    start: b.x0,
+    end: b.x1
+  }));
 }
 
 export function DistributionChart({ data, column }: DistributionChartProps) {

--- a/bespoke-dataset-viewer/components/dataset-viewer/DistributionChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/DistributionChart.tsx
@@ -71,6 +71,18 @@ export function DistributionChart({ data, column }: DistributionChartProps) {
           <YAxis />
           <Tooltip 
             formatter={(value: number) => [`Count: ${value}`, displayName]}
+            contentStyle={{
+              backgroundColor: 'var(--tooltip-text-bg)',
+              border: '1px solid var(--border)',
+              borderRadius: '4px',
+              color: 'var(--tooltip-text)',
+              boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+            }}
+            labelStyle={{
+              color: 'var(--tooltip-text)',
+              marginBottom: '4px'
+            }}
+            cursor={{ fill: 'var(--tooltip-bg)', opacity: 0.2 }}
           />
           <Bar 
             dataKey="count" 

--- a/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
@@ -91,7 +91,7 @@ export function TimeSeriesChart({ data }: TimeSeriesChartProps) {
   return (
     <div className="w-full">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-semibold">Request Rate Over Time</h2>
+        <h2 className="text-xl font-semibold">Requests and Responses Over Time</h2>
         <div className="flex gap-2">
           <Button 
             variant={timeUnit === 'second' ? 'default' : 'outline'}

--- a/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { DataItem } from '@/types/dataset'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid, Area, ComposedChart } from 'recharts'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface TimeSeriesChartProps {
+  data: DataItem[]
+}
+
+type TimeUnit = 'second' | 'minute' | 'hour'
+
+interface TimePoint {
+  timestamp: number
+  requestsSent: number
+  responsesReceived: number
+  timeLabel: string
+}
+
+function aggregateByTimeUnit(data: DataItem[], unit: TimeUnit): TimePoint[] {
+  const timePoints = new Map<number, TimePoint>()
+  
+  // Convert to milliseconds
+  const interval = unit === 'second' ? 1000 : 
+                  unit === 'minute' ? 60 * 1000 : 
+                  60 * 60 * 1000
+
+  // Find min and max timestamps
+  const timestamps = data.flatMap(item => [
+    new Date(item.created_at).getTime(),
+    new Date(item.finished_at).getTime()
+  ])
+  const minTime = Math.floor(Math.min(...timestamps) / interval) * interval
+  const maxTime = Math.ceil(Math.max(...timestamps) / interval) * interval
+
+  // Initialize all time points
+  for (let t = minTime; t <= maxTime; t += interval) {
+    timePoints.set(t, {
+      timestamp: t,
+      requestsSent: 0,
+      responsesReceived: 0,
+      timeLabel: formatTimeLabel(t, unit)
+    })
+  }
+
+  // Count requests sent and responses received in each interval
+  data.forEach(item => {
+    const createdTime = Math.floor(new Date(item.created_at).getTime() / interval) * interval
+    const finishedTime = Math.floor(new Date(item.finished_at).getTime() / interval) * interval
+    
+    const createdPoint = timePoints.get(createdTime)
+    if (createdPoint) {
+      createdPoint.requestsSent++
+    }
+    
+    const finishedPoint = timePoints.get(finishedTime)
+    if (finishedPoint) {
+      finishedPoint.responsesReceived++
+    }
+  })
+
+  return Array.from(timePoints.values())
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+function formatTimeLabel(timestamp: number, unit: TimeUnit): string {
+  const date = new Date(timestamp)
+  if (unit === 'second') {
+    return date.toLocaleTimeString([], { 
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    })
+  } else if (unit === 'minute') {
+    return date.toLocaleTimeString([], { 
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  } else {
+    return date.toLocaleTimeString([], { 
+      hour: '2-digit'
+    })
+  }
+}
+
+export function TimeSeriesChart({ data }: TimeSeriesChartProps) {
+  const [timeUnit, setTimeUnit] = useState<TimeUnit>('second')
+  const timeSeriesData = aggregateByTimeUnit(data, timeUnit)
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold">Request Rate Over Time</h2>
+        <div className="flex gap-2">
+          <Button 
+            variant={timeUnit === 'second' ? 'default' : 'outline'}
+            onClick={() => setTimeUnit('second')}
+            size="sm"
+          >
+            Per Second
+          </Button>
+          <Button 
+            variant={timeUnit === 'minute' ? 'default' : 'outline'}
+            onClick={() => setTimeUnit('minute')}
+            size="sm"
+          >
+            Per Minute
+          </Button>
+          <Button 
+            variant={timeUnit === 'hour' ? 'default' : 'outline'}
+            onClick={() => setTimeUnit('hour')}
+            size="sm"
+          >
+            Per Hour
+          </Button>
+        </div>
+      </div>
+      
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={timeSeriesData}
+            margin={{ top: 10, right: 30, left: 20, bottom: 15 }}
+          >
+            <defs>
+              <linearGradient id="requestsGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#8884d8" stopOpacity={0.2}/>
+                <stop offset="95%" stopColor="#8884d8" stopOpacity={0.05}/>
+              </linearGradient>
+              <linearGradient id="responsesGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#82ca9d" stopOpacity={0.2}/>
+                <stop offset="95%" stopColor="#82ca9d" stopOpacity={0.05}/>
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="#888" opacity={0.2} />
+            <XAxis
+              dataKey="timeLabel"
+              fontSize={12}
+              angle={-45}
+              textAnchor="end"
+              height={70}
+              stroke="#888"
+            />
+            <YAxis stroke="#888" />
+            <Tooltip
+              labelFormatter={(label) => `Time: ${label}`}
+              formatter={(value: number, name: string) => [
+                `${value} ${name === 'requestsSent' ? 'requests' : 'responses'}`,
+                name === 'requestsSent' ? 'Requests Sent' : 'Responses Received'
+              ]}
+              contentStyle={{
+                backgroundColor: 'var(--tooltip-text-bg)',
+                border: '1px solid var(--border)',
+                borderRadius: '4px',
+                color: 'var(--tooltip-text)'
+              }}
+              labelStyle={{
+                color: 'var(--tooltip-text)'
+              }}
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="requestsSent"
+              fill="url(#requestsGradient)"
+              stroke="#8884d8"
+              strokeWidth={2}
+              name="Requests Sent"
+              dot={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="responsesReceived"
+              fill="url(#responsesGradient)"
+              stroke="#82ca9d"
+              strokeWidth={2}
+              name="Responses Received"
+              dot={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+} 

--- a/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { DataItem } from '@/types/dataset'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid, Area, ComposedChart } from 'recharts'
+import { XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid, Area, ComposedChart } from 'recharts'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 

--- a/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
+++ b/bespoke-dataset-viewer/components/dataset-viewer/TimeSeriesChart.tsx
@@ -146,8 +146,8 @@ export function TimeSeriesChart({ data }: TimeSeriesChartProps) {
             <Tooltip
               labelFormatter={(label) => `Time: ${label}`}
               formatter={(value: number, name: string) => [
-                `${value} ${name === 'requestsSent' ? 'requests' : 'responses'}`,
-                name === 'requestsSent' ? 'Requests Sent' : 'Responses Received'
+                value,
+                name
               ]}
               contentStyle={{
                 backgroundColor: 'var(--tooltip-text-bg)',

--- a/bespoke-dataset-viewer/components/ui/sortable-table.tsx
+++ b/bespoke-dataset-viewer/components/ui/sortable-table.tsx
@@ -220,9 +220,9 @@ export function SortableTable({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {paginatedData.map(row => (
+            {paginatedData.map((row, rowIndex) => (
               <motion.tr
-                key={getRowKey(row)}
+                key={`${rowIndex}-${getRowKey(row)}`}
                 className={cn(
                   onRowClick ? "cursor-pointer hover:bg-muted/50" : "",
                   rowProps?.(row)?.className
@@ -230,8 +230,10 @@ export function SortableTable({
                 onClick={() => onRowClick?.(row)}
                 {...(rowProps?.(row) || {})}
               >
-                {orderedColumns.map(column => (
-                  <TableCell key={`${getRowKey(row)}-${column.key}`}>
+                {orderedColumns.map((column, colIndex) => (
+                  <TableCell 
+                    key={`${rowIndex}-${colIndex}-${getRowKey(row)}-${column.key}`}
+                  >
                     {renderCell(getCellContent(row, column.key), truncateConfig.enabled)}
                   </TableCell>
                 ))}

--- a/bespoke-dataset-viewer/lib/utils.ts
+++ b/bespoke-dataset-viewer/lib/utils.ts
@@ -30,6 +30,8 @@ export const getColumnValue = (item: DataItem, column: string): string => {
       return item.raw_response.usage?.total_tokens?.toString() ||
         item.raw_response.response?.body?.usage?.total_tokens?.toString() ||
         "N/A";
+    case "generation_time":
+      return ((new Date(item.finished_at).getTime() - new Date(item.created_at).getTime()) / 1000).toString();
     default:
       return "N/A";
   }

--- a/bespoke-dataset-viewer/package-lock.json
+++ b/bespoke-dataset-viewer/package-lock.json
@@ -26,6 +26,7 @@
         "fs": "^0.0.1-security",
         "lucide-react": "^0.454.0",
         "next": "^15.0.2",
+        "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.13.3",
@@ -2944,9 +2945,9 @@
       "optional": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6522,6 +6523,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/promise-inflight": {

--- a/bespoke-dataset-viewer/package.json
+++ b/bespoke-dataset-viewer/package.json
@@ -27,6 +27,7 @@
     "fs": "^0.0.1-security",
     "lucide-react": "^0.454.0",
     "next": "^15.0.2",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.13.3",

--- a/bespoke-dataset-viewer/types/dataset.ts
+++ b/bespoke-dataset-viewer/types/dataset.ts
@@ -15,7 +15,8 @@ export type DataItem = {
     original_row: Record<string, any>
     original_row_idx: number
   }
-  
+  created_at: string
+  finished_at: string
 }
 
 export interface Run {

--- a/src/bespokelabs/curator/request_processor/generic_response.py
+++ b/src/bespokelabs/curator/request_processor/generic_response.py
@@ -23,5 +23,5 @@ class GenericResponse(BaseModel):
     raw_response: Optional[Dict[str, Any]]
     raw_request: Optional[Dict[str, Any]] = None
     generic_request: GenericRequest
-    created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
-    finished_at: Optional[datetime.datetime] = None
+    created_at: datetime.datetime
+    finished_at: datetime.datetime

--- a/src/bespokelabs/curator/request_processor/generic_response.py
+++ b/src/bespokelabs/curator/request_processor/generic_response.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from .generic_request import GenericRequest
+import datetime
 
 """A generic response model for LLM API requests.
 
@@ -22,3 +23,5 @@ class GenericResponse(BaseModel):
     raw_response: Optional[Dict[str, Any]]
     raw_request: Optional[Dict[str, Any]] = None
     generic_request: GenericRequest
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
+    finished_at: Optional[datetime.datetime] = None

--- a/src/bespokelabs/curator/request_processor/generic_response.py
+++ b/src/bespokelabs/curator/request_processor/generic_response.py
@@ -14,6 +14,8 @@ Attributes:
     raw_response: The raw response data from the API.
     raw_request: The raw request data. Will be None for BatchAPI requests.
     generic_request: The associated GenericRequest object.
+    created_at: The datetime when the request was created.
+    finished_at: The datetime when the request was finished.
 """
 
 

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -500,24 +500,24 @@ class BatchWatcher:
         response_file = f"{self.working_dir}/responses_{request_file_idx}"
 
         generic_request_map = {}
+        request_creation_times = {}  # Track creation times for requests
         with open(request_file, "r") as f:
             for line in f:
                 generic_request = GenericRequest.model_validate_json(line)
-                generic_request_map[generic_request.original_row_idx] = (
-                    generic_request
-                )
+                generic_request_map[generic_request.original_row_idx] = generic_request
+                request_creation_times[generic_request.original_row_idx] = datetime.datetime.now()
 
         with open(response_file, "w") as f:
             for raw_response in file_content.text.splitlines():
                 raw_response = json.loads(raw_response)
-                generic_request = generic_request_map[
-                    int(raw_response["custom_id"])
-                ]
+                request_idx = int(raw_response["custom_id"])
+                generic_request = generic_request_map[request_idx]
 
                 generic_response = GenericResponse(
                     raw_response=raw_response,
                     raw_request=None,
                     generic_request=generic_request,
+                    created_at=request_creation_times[request_idx],
                     finished_at=datetime.datetime.now()
                 )
 

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -8,7 +8,7 @@ import aiofiles
 from openai import AsyncOpenAI
 from openai.types import Batch
 from tqdm import tqdm
-
+import datetime
 from bespokelabs.curator.dataset import Dataset
 from bespokelabs.curator.prompter.prompt_formatter import PromptFormatter
 from bespokelabs.curator.request_processor.base_request_processor import (
@@ -518,6 +518,7 @@ class BatchWatcher:
                     raw_response=raw_response,
                     raw_request=None,
                     generic_request=generic_request,
+                    finished_at=datetime.datetime.now()
                 )
 
                 # TODO(Ryan): Add more specific error handling

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -519,6 +519,7 @@ class APIRequest:
     token_consumption: int
     attempts_left: int
     result: list = field(default_factory=list)
+    created_at: datetime.datetime = field(default_factory=datetime.datetime.now)
 
     async def call_api(
         self,
@@ -571,6 +572,7 @@ class APIRequest:
                     raw_request=self.api_specific_request_json,
                     raw_response=None,
                     generic_request=self.generic_request,
+                    created_at=self.created_at,
                     finished_at=datetime.datetime.now()
                 )
                 append_generic_response(generic_response, save_filepath)
@@ -591,6 +593,7 @@ class APIRequest:
                 raw_request=self.api_specific_request_json,
                 raw_response=response,
                 generic_request=self.generic_request,
+                created_at=self.created_at,
                 finished_at=datetime.datetime.now()
             )
             append_generic_response(generic_response, save_filepath)

--- a/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_online_request_processor.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Set, Tuple, TypeVar
 import resource
+import datetime
 
 import aiohttp
 import requests
@@ -570,6 +571,7 @@ class APIRequest:
                     raw_request=self.api_specific_request_json,
                     raw_response=None,
                     generic_request=self.generic_request,
+                    finished_at=datetime.datetime.now()
                 )
                 append_generic_response(generic_response, save_filepath)
                 status_tracker.num_tasks_in_progress -= 1
@@ -589,6 +591,7 @@ class APIRequest:
                 raw_request=self.api_specific_request_json,
                 raw_response=response,
                 generic_request=self.generic_request,
+                finished_at=datetime.datetime.now()
             )
             append_generic_response(generic_response, save_filepath)
             status_tracker.num_tasks_in_progress -= 1


### PR DESCRIPTION
**Changes**:
- added generation time logging
- add generation time UI, in distribution view, sortable table view and detail view
- added requests & responses overlay time series plot (default view)
- enabled all with streaming
- Resolves 
  - #145 
  - partially address #105 for better bins, but addressing outliers, still need work. Perhaps selecting a range for user to zoom in if they see most of the points lie in a small region?
  - #150

New GenericResponse:
```python
class GenericResponse(BaseModel):
    response_message: Optional[Dict[str, Any]] | str = None
    response_errors: Optional[List[str]] = None
    raw_response: Optional[Dict[str, Any]]
    raw_request: Optional[Dict[str, Any]] = None
    generic_request: GenericRequest
    created_at: datetime.datetime
    finished_at: datetime.datetime
```

https://github.com/user-attachments/assets/a8751cb1-4bf4-4921-b17d-b3fd8726803c

https://github.com/user-attachments/assets/57877738-0d83-49ca-98c7-3ecb8c5a3e7a

Nice to have: 
- https://www.infoworld.com/article/2334935/recharts-intro-to-javascript-charting.html (brush component in UI), for selecting time range