### PR TITLE
Increase max retry to 50

### DIFF
--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import glob
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import resource
 from dataclasses import dataclass
 
 import aiofiles
-import glob
 import litellm
 from openai import AsyncOpenAI
 from openai.types import Batch
@@ -32,7 +32,7 @@ MAX_BYTES_PER_BATCH = 200 * 1024 * 1024
 # NOTE(Ryan): This allows us to stay under the rate limit when submitting ~1,000 batches at a time
 # When submitting >1,000 batches the batch submission and batch download operations get rate limited
 MAX_CONCURRENT_BATCH_OPERATIONS = 100
-MAX_RETRIES_PER_OPERATION = 5
+MAX_RETRIES_PER_OPERATION = 50
 
 
 class OpenAIBatchRequestProcessor(BaseRequestProcessor):


### PR DESCRIPTION
We are still hitting timeouts from OpenAI. Will retry much more aggressively.

```
Error Type: TASK_EXECUTION_EXCEPTION

User exception:
10_067307_1/runtime_resources/pip/14f34acc790047a95e39a14509b14c99a0377d40/virtualenv/lib/python3.10/site-packages/openai/_base_client.py", line 1581, in _request
 return await self._retry_request(
 File "/tmp/ray/session_2024-11-27_21-23-10_067307_1/runtime_resources/pip/14f34acc790047a95e39a14509b14c99a0377d40/virtualenv/lib/python3.10/site-packages/openai/_base_client.py", line 1591, in _request
 raise APITimeoutError(request=request) from err
openai.APITimeoutError: Request timed out.
```

Note that OpenAI client will apply exponential backoff, up to at most 8 seconds: https://github.com/openai/openai-python/blob/bb9c2de913279acc89e79f6154173a422f31de45/src/openai/_base_client.py#L704, so we are not bombarding OpenAI's server with requests here.