### PR TITLE
Use huggingface modified pickler to fix path-dependent caching

### DIFF
--- a/src/bespokelabs/curator/prompter/prompter.py
+++ b/src/bespokelabs/curator/prompter/prompter.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from io import BytesIO
 from typing import Any, Callable, Dict, Iterable, Optional, Type, TypeVar, Union
 
-import dill
+from datasets.utils._dill import Pickler
 from datasets import Dataset
 from pydantic import BaseModel
 from xxhash import xxh64
@@ -311,7 +311,7 @@ def _get_function_hash(func) -> str:
         return xxh64("").hexdigest()
 
     file = BytesIO()
-    dill.Pickler(file, recurse=True).dump(func)
+    Pickler(file, recurse=True).dump(func)
     return xxh64(file.getvalue()).hexdigest()
 
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -113,3 +113,95 @@ def test_nested_call_caching(tmp_path):
     # Count cache directories, excluding metadata.db
     cache_dirs = [d for d in tmp_path.glob("*") if d.name != "metadata.db"]
     assert len(cache_dirs) == 2, f"Expected 2 cache directory but found {len(cache_dirs)}"
+
+
+def test_function_hash_dir_change():
+    """Test that identical functions in different directories but same base filename produce the same hash."""
+    import logging
+    import os
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    from bespokelabs.curator.prompter.prompter import _get_function_hash
+
+    # Set up logging to write to a file in the current directory
+    debug_log = Path("function_debug.log")
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(message)s", filename=str(debug_log), filemode="w"
+    )
+    logger = logging.getLogger(__name__)
+
+    def dump_function_details(func, prefix):
+        """Helper to dump all function details."""
+        print(f"\n{prefix} details:")  # Print to stdout as well
+        logger.debug(f"\n{prefix} details:")
+        # Basic attributes
+        details = {
+            "__name__": func.__name__,
+            "__module__": func.__module__,
+            "__qualname__": func.__qualname__,
+            "__code__.co_filename": func.__code__.co_filename,
+            "__code__.co_name": func.__code__.co_name,
+            "__code__.co_firstlineno": func.__code__.co_firstlineno,
+            "__code__.co_consts": func.__code__.co_consts,
+            "__code__.co_names": func.__code__.co_names,
+            "__code__.co_varnames": func.__code__.co_varnames,
+            "__code__.co_code": func.__code__.co_code.hex(),
+            "__code__.co_flags": func.__code__.co_flags,
+            "__code__.co_stacksize": func.__code__.co_stacksize,
+            "__code__.co_freevars": func.__code__.co_freevars,
+            "__code__.co_cellvars": func.__code__.co_cellvars,
+            "__globals__ keys": sorted(func.__globals__.keys()),
+            "__closure__": func.__closure__,
+            "__defaults__": func.__defaults__,
+            "__kwdefaults__": func.__kwdefaults__,
+        }
+
+        for key, value in details.items():
+            msg = f"  {key}: {value}"
+            print(msg)  # Print to stdout
+            logger.debug(msg)  # Log to file
+
+    def create_function(name, tmp_path):
+        # Create a temporary file with a function definition
+        path = tmp_path / f"{name}.py"
+        with open(path, "w") as f:
+            f.write(
+                """
+def test_func():
+    x = 42  # Add a constant
+    y = "Hello"  # Add a string constant
+    z = [1, 2, 3]  # Add a list constant
+    return f"{y}, {x}! {z}"  # Use all constants
+"""
+            )
+
+        # Import the function from the file
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.test_func
+
+    # Create two identical functions in different files
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        func1 = create_function("module1", Path(tmp_dir))
+        func2 = create_function("module1", Path(tmp_dir))
+
+        # Dump detailed information about both functions
+        dump_function_details(func1, "Function 1")
+        dump_function_details(func2, "Function 2")
+
+        # Both should produce the same hash
+        hash1 = _get_function_hash(func1)
+        hash2 = _get_function_hash(func2)
+        print(f"\nHash comparison:")  # Print to stdout
+        print(f"  hash1: {hash1}")
+        print(f"  hash2: {hash2}")
+        logger.debug(f"\nHash comparison:")
+        logger.debug(f"  hash1: {hash1}")
+        logger.debug(f"  hash2: {hash2}")
+
+        assert hash1 == hash2, "Identical functions should produce the same hash"


### PR DESCRIPTION
Similar to https://github.com/bespokelabsai/curator/issues/215, this is causing a ton of cache misses in DCFT since the runtime path changes depending on the ray package name when a job is submitted to the Ray remote cluster, e.g. the path is `/tmp/ray/ray_pkg_xzy`

the Ray package name changes whenever there is a change in the local github repository.

HuggingFace pickler overcomes this problem by modifying the filename: https://github.com/huggingface/datasets/blob/2049c00921c59cdeb835137a1c49639cf175af07/src/datasets/utils/_dill.py#L252