### PR TITLE
Graceful error handling for missing requests

### DIFF
--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -222,10 +222,12 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
                 request_idx = int(raw_response["custom_id"])
 
                 if request_idx not in generic_request_map:
-                    raise ValueError(
+                    logger.warning(
                         f"Request {request_idx} not found in generic_request_map. response_file: {response_file}, "
-                        f"request_file: {request_file}."
+                        f"request_file: {request_file}. The request files might have been partially corrupted. Will skip "
+                        f"this response."
                     )
+                    continue
 
                 if raw_response["response"]["status_code"] != 200:
                     logger.warning(

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -220,7 +220,12 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
             for raw_response in responses.text.splitlines():
                 raw_response = json.loads(raw_response)
                 request_idx = int(raw_response["custom_id"])
-                generic_request = generic_request_map[request_idx]
+
+                if request_idx not in generic_request_map:
+                    raise ValueError(
+                        f"Request {request_idx} not found in generic_request_map. response_file: {response_file}, "
+                        f"request_file: {request_file}."
+                    )
 
                 if raw_response["response"]["status_code"] != 200:
                     logger.warning(

--- a/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/openai_batch_request_processor.py
@@ -224,7 +224,7 @@ class OpenAIBatchRequestProcessor(BaseRequestProcessor):
                 if request_idx not in generic_request_map:
                     logger.warning(
                         f"Request {request_idx} not found in generic_request_map. response_file: {response_file}, "
-                        f"request_file: {request_file}. The request files might have been partially corrupted. Will skip "
+                        f"request_file: {request_file}. The request files might have been incomplete. Will skip "
                         f"this response."
                     )
                     continue


### PR DESCRIPTION
Some returned reponses don't have corresponding requests in `requests.jsonl`. When I double-check, it turns out that some of these requests.jsonl files don't have enough responses:

```
(bespokelabs-curator-py3.11) (base) trung@trung-cpu:~/curator$ gsutil cp gs://dcft-data-gcp/curator-cache/open-orca-t0_gpt-4o-mini_scale_x8__llm_judge_filter/66baa891a262d994/requests_92.jsonl .
Copying gs://dcft-data-gcp/curator-cache/open-orca-t0_gpt-4o-mini_scale_x8__llm_judge_filter/66baa891a262d994/requests_92.jsonl...
\ [1 files][ 53.3 MiB/ 53.3 MiB]                                                
Operation completed over 1 objects/53.3 MiB.                                     
(bespokelabs-curator-py3.11) (base) trung@trung-cpu:~/curator$ cat requests_92.jsonl | wc -l
9966
```

This file is supposed to have 10000 requests since we set that as the batch size.

It's unclear where the requests are getting lost (perhaps during remote sync), but we should probably still gracefully recover by skipping the request, since 9966/10000 requests still have successful responses.