### PR TITLE
fix: set backend to None for SimpleLLM class by default

### DIFF
--- a/src/bespokelabs/curator/llm/simple_llm.py
+++ b/src/bespokelabs/curator/llm/simple_llm.py
@@ -15,7 +15,7 @@ class SimpleLLM:
     For more complex use cases (e.g. structured outputs and custom prompt functions), see the LLM class.
     """
 
-    def __init__(self, model_name: str, backend: str = "openai"):
+    def __init__(self, model_name: str, backend: str = None):
         """Initialize the SimpleLLM instance."""
         self._model_name = model_name
         self._backend = backend


### PR DESCRIPTION
As a principle, we want to route users to the right backend without them having to play around and understand this abstraction. This simplifies this [example](https://github.com/bespokelabsai/curator?tab=readme-ov-file#use-litellm-backend-for-calling-other-models) in the README to

```
from bespokelabs import curator
llm = curator.SimpleLLM(model_name="claude-3-5-sonnet-20240620")
poem = llm("Write a poem about the importance of data in AI.")
print(poem)
```