### PR TITLE
Add fix_json check

### DIFF
--- a/src/bespokelabs/curator/request_processor/config.py
+++ b/src/bespokelabs/curator/request_processor/config.py
@@ -139,7 +139,6 @@ class OfflineBackendParams(BaseBackendParams, total=False):
     enforce_eager: t.Optional[bool]
     max_model_length: t.Optional[int]
     max_tokens: t.Optional[int]
-    min_tokens: t.Optional[int]
     gpu_memory_utilization: t.Optional[float]
     batch_size: t.Optional[int]
 

--- a/src/bespokelabs/curator/request_processor/config.py
+++ b/src/bespokelabs/curator/request_processor/config.py
@@ -139,6 +139,7 @@ class OfflineBackendParams(BaseBackendParams, total=False):
     enforce_eager: t.Optional[bool]
     max_model_length: t.Optional[int]
     max_tokens: t.Optional[int]
+    min_tokens: t.Optional[int]
     gpu_memory_utilization: t.Optional[float]
     batch_size: t.Optional[int]
 

--- a/src/bespokelabs/curator/request_processor/offline/vllm_offline_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/offline/vllm_offline_request_processor.py
@@ -205,7 +205,8 @@ class VLLMOfflineRequestProcessor(BaseOfflineRequestProcessor):
 
         for completion, request in zip(completions, requests):
             response_message = completion.outputs[0].text
-            response_message = self.fix_json(response_message)
+            if response_format is not None and self.support_structured_output:
+                response_message = self.fix_json(response_message)
 
             raw_response = {
                 "request_id": completion.request_id,

--- a/tests/integrations/test_all.py
+++ b/tests/integrations/test_all.py
@@ -331,4 +331,4 @@ def test_basic_offline(temp_working_dir, mock_dataset):
 
         # Verify response content
         recipes = "".join([recipe[0] for recipe in dataset.to_pandas().values.tolist()])
-        assert _hash_string(recipes) == "606496dab9c92f00eccec0ea4e7dd518155cfd1dbb573fb0c924c85e038e0c8f"
+        assert _hash_string(recipes) == "f0e229cb0b9c6d60930abda07998fe5870c7e94331ca877af8f400f9697213ee"


### PR DESCRIPTION
This fixes an issue where `fix_json` is applied even if structured output is not requested in the VLLM offline request processor.