### PR TITLE
feat: bump 0.1.15 + better publishing process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,3 @@
 .DS_Store
 __pycache__
 .vscode
-
-# Static / Build
-/src/bespokelabs/curator/viewer/static
-/dist

--- a/publish_pkg.sh
+++ b/publish_pkg.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build Curator Viewer
+python build_pkg.py
+
+# Build Curator Package
+poetry build
+
+# Publish Curator Package
+poetry publish
+
+# Clean up
+rm -rf src/bespokelabs/curator/viewer/static
+rm -rf dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bespokelabs-curator"
-version = "0.1.15rc5"
+version = "0.1.15"
 description = "Bespoke Labs Curator"
 authors = ["Bespoke Labs <company@bespokelabs.ai>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bespokelabs-curator"
-version = "0.1.14"
+version = "0.1.15rc5"
 description = "Bespoke Labs Curator"
 authors = ["Bespoke Labs <company@bespokelabs.ai>"]
 readme = "README.md"


### PR DESCRIPTION
* bump version to 0.1.15
* i realized that the .gitignore breaking the curator viewer in our builds since `poetry build` looks at .gitignore and `/src/bespokelabs/curator/viewer/static` and `/dist` are needed for a working UI. i've edited the .gitignore, and also added a publishing script that should encapsulate the publishing process better