### PR TITLE
Allow lists of messages as simple input

### DIFF
--- a/src/bespokelabs/curator/llm/llm.py
+++ b/src/bespokelabs/curator/llm/llm.py
@@ -176,10 +176,10 @@ class LLM:
             # A single string is converted to a dataset with a single row
             dataset = Dataset.from_list([{"prompt": dataset}])
         elif not isinstance(dataset, Dataset) and dataset is not None:
-            # Wrap the iterable in a generator to convert strings to dictionaries
+            # Wrap the iterable in a generator, the prompt is expected to be a prompt string or a list of messages
             def wrapped_iterable():
                 for input in dataset:
-                    if isinstance(input, str):
+                    if isinstance(input, str) or isinstance(input, list):
                         yield {"prompt": input}
                     else:
                         yield input

--- a/src/bespokelabs/curator/llm/llm.py
+++ b/src/bespokelabs/curator/llm/llm.py
@@ -175,6 +175,9 @@ class LLM:
         if isinstance(dataset, str):
             # A single string is converted to a dataset with a single row
             dataset = Dataset.from_list([{"prompt": dataset}])
+        elif isinstance(dataset, list) and all(isinstance(item, dict) and "role" in item and "content" in item for item in dataset):
+            # A list of messages is converted to a dataset with a single row
+            dataset = Dataset.from_list([{"prompt": dataset}])
         elif not isinstance(dataset, Dataset) and dataset is not None:
             # Wrap the iterable in a generator, the prompt is expected to be a prompt string or a list of messages
             def wrapped_iterable():

--- a/tests/unittests/test_dataset_conversion.py
+++ b/tests/unittests/test_dataset_conversion.py
@@ -1,0 +1,36 @@
+import pytest
+from datasets import Dataset
+
+from bespokelabs.curator.llm.llm import _convert_to_dataset, _is_message_list
+
+
+@pytest.fixture
+def single_message():
+    return [{"role": "user", "content": "test"}]
+
+
+@pytest.fixture
+def conversation():
+    return [{"role": "user", "content": "test"}, {"role": "assistant", "content": "test"}]
+
+
+@pytest.fixture
+def conversation_with_system():
+    return [{"role": "system", "content": "test"}, {"role": "user", "content": "test"}, {"role": "assistant", "content": "test"}]
+
+
+def test_is_message_list(single_message, conversation, conversation_with_system):
+    assert _is_message_list(single_message)
+    assert _is_message_list(conversation)
+    assert _is_message_list(conversation_with_system)
+    assert not _is_message_list([{"col": "row"}])
+
+
+def test_convert_to_dataset(single_message, conversation, conversation_with_system):
+    assert _convert_to_dataset("test").to_list() == [{"prompt": "test"}]
+    assert _convert_to_dataset(single_message).to_list() == [{"prompt": single_message}]
+    assert _convert_to_dataset(conversation).to_list() == [{"prompt": conversation}]
+    assert _convert_to_dataset(conversation_with_system).to_list() == [{"prompt": conversation_with_system}]
+    assert _convert_to_dataset([conversation, conversation_with_system]).to_list() == [{"prompt": conversation}, {"prompt": conversation_with_system}]
+    assert _convert_to_dataset(Dataset.from_list([{"prompt": "test"}])).to_list() == [{"prompt": "test"}]
+    assert _convert_to_dataset([{"prompt": "test"}]).to_list() == [{"prompt": "test"}]


### PR DESCRIPTION
Allowing for 

Right now we allow 
```
llm("hi")
```
```
llm(["hi", "tell me a joke"])
```

I'm looking to also allow 
```
llm(list[messages])
```

like
```
llm([[{'role': 'user', 'content': 'What are the names of some famous actors that started their careers on Broadway?'}], [{'role': 'user', 'content': 'How did US states get their names?'}]])
```