### PR TITLE
feat: add support for returning the full completions object + some changes to support deepseek models

### DIFF
--- a/src/bespokelabs/curator/llm/llm.py
+++ b/src/bespokelabs/curator/llm/llm.py
@@ -29,6 +29,7 @@ class LLM:
     """Interface for prompting LLMs."""
 
     response_format: Type[BaseModel] | None = None
+    return_completions_object: bool = False
 
     def prompt(self, input: _DictOrBaseModel) -> _DictOrBaseModel:
         """Prompt the LLM.
@@ -125,7 +126,13 @@ class LLM:
         self.batch_mode = batch
 
         self._request_processor = _RequestProcessorFactory.create(
-            params=backend_params, model_name=model_name, batch=batch, response_format=response_format, backend=backend, generation_params=generation_params
+            params=backend_params,
+            model_name=model_name,
+            batch=batch,
+            response_format=response_format,
+            backend=backend,
+            generation_params=generation_params,
+            return_completions_object=self.return_completions_object,
         )
 
     def _hash_fingerprint(self, dataset_hash, disable_cache):

--- a/src/bespokelabs/curator/request_processor/batch/anthropic_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/batch/anthropic_batch_request_processor.py
@@ -215,7 +215,10 @@ class AnthropicBatchRequestProcessor(BaseBatchRequestProcessor):
 
         if result_type == "succeeded":
             response_body = raw_response["result"]["message"]
-            response_message_raw = response_body["content"][0]["text"]
+            if self.config.return_completions_object:
+                response_message_raw = response_body
+            else:
+                response_message_raw = response_body["content"][0]["text"]
             usage = response_body.get("usage", {})
 
             token_usage = TokenUsage(

--- a/src/bespokelabs/curator/request_processor/batch/openai_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/batch/openai_batch_request_processor.py
@@ -154,7 +154,10 @@ class OpenAIBatchRequestProcessor(BaseBatchRequestProcessor, OpenAIRequestMixin)
             cost = None
         else:
             response_body = raw_response["response"]["body"]
-            response_message_raw = response_body["choices"][0]["message"]["content"]
+            if self.config.return_completions_object:
+                response_message_raw = response_body
+            else:
+                response_message_raw = response_body["choices"][0]["message"]["content"]
             usage = response_body.get("usage", {})
 
             # TODO(Ryan) will want to resubmit requests like in the online case

--- a/src/bespokelabs/curator/request_processor/config.py
+++ b/src/bespokelabs/curator/request_processor/config.py
@@ -26,6 +26,7 @@ class RequestProcessorConfig(BaseModel):
     request_timeout: int = Field(default=10 * 60, gt=0)
     require_all_responses: bool = Field(default=True)
     generation_params: dict = Field(default_factory=dict)
+    return_completions_object: bool = False
 
     class Config:
         """BaseModel Setup class."""

--- a/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
@@ -274,7 +274,10 @@ class LiteLLMOnlineRequestProcessor(BaseOnlineRequestProcessor):
                 response_message = response.model_dump() if hasattr(response, "model_dump") else response
             else:
                 completion_obj = await litellm.acompletion(**request.api_specific_request, timeout=self.config.request_timeout)
-                response_message = completion_obj["choices"][0]["message"]["content"]
+                if self.config.return_completions_object:
+                    response_message = dict(completion_obj)
+                else:
+                    response_message = completion_obj["choices"][0]["message"]["content"]
         except litellm.RateLimitError as e:
             status_tracker.time_of_last_rate_limit_error = time.time()
             status_tracker.num_rate_limit_errors += 1

--- a/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
@@ -51,11 +51,11 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             self.url = self.config.base_url + self._DEFAULT_COMPLETION_SUFFIX
 
         if self.config.base_url == "https://api.deepseek.com":
-            self.api_key = os.getenv("DEEPSEEK_API_KEY")
             # DeepSeek does not return rate limits in headers
             # https://api-docs.deepseek.com/quick_start/rate_limit.
             # And sending an empty request for rate limits results in a 400 error like this:
             # {'error': {'message': 'Empty input messages', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
+            self.api_key = os.getenv("DEEPSEEK_API_KEY")
         else:
             self.api_key = os.getenv("OPENAI_API_KEY")
             self.header_based_max_requests_per_minute, self.header_based_max_tokens_per_minute = self.get_header_based_rate_limits()
@@ -98,9 +98,9 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             Default implementation returns a conservative estimate.
             Override this method for more accurate model-specific estimates.
         """
-        try:
+        if self.config.model in litellm.model_cost:
             return litellm.get_max_tokens(model=self.config.model) // 4
-        except Exception:
+        else:
             return 0
 
     def estimate_total_tokens(self, messages: list) -> _TokenCount:


### PR DESCRIPTION
This PR
- Add support for returning the full completions object with 
- Make several changes to make deepseek models compatible: in particular, it turns out litellm does not fill out the reasoning_content field when it returns the response, so we need to route deepseek models to openai backend to get the raw response

I'll add more tests for this later.