### PR TITLE
fix: remove args[0] in cost

### DIFF
--- a/src/bespokelabs/curator/cost.py
+++ b/src/bespokelabs/curator/cost.py
@@ -18,7 +18,7 @@ class _LitellmCostProcessor:
             cost_to_complete = litellm.completion_cost(*args, **kwargs)
         except litellm.exceptions.BadRequestError:
             cost_to_complete = 0.0
-            model = kwargs.get("model", None) or args[0]
+            model = kwargs.get("model", None)
             logging.warn(f"Could not retrieve cost for the model: {model}")
         if self.batch:
             cost_to_complete *= 0.5


### PR DESCRIPTION
This function never gets called with args, see https://github.com/bespokelabsai/curator/blob/724f7e52e82bafba39fcb2de2f2ba56eaa387f18/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py#L191

As a result, when a model does not have cost, this errors out, even if the request is actually successful.

This breaks R1 on DeepInfra since we don't have cost for it.