### PR TITLE
fix: check model in litellm.cost instead of try catching

### DIFF
--- a/src/bespokelabs/curator/cost.py
+++ b/src/bespokelabs/curator/cost.py
@@ -14,11 +14,11 @@ class _LitellmCostProcessor:
     def cost(self, *args, completion_window="*", **kwargs):
         import litellm
 
-        try:
+        model = kwargs.get("model", None)
+        cost_to_complete = 0.0
+        if model in litellm.model_cost:
             cost_to_complete = litellm.completion_cost(*args, **kwargs)
-        except litellm.exceptions.BadRequestError:
-            cost_to_complete = 0.0
-            model = kwargs.get("model", None)
+        else:
             logging.warn(f"Could not retrieve cost for the model: {model}")
         if self.batch:
             cost_to_complete *= 0.5


### PR DESCRIPTION
The issue is that if the exception isn't litellm.exceptions.BadRequestError, we will error out. In fact this happened with DeepSeek-R1 on deepinfra
```
Exception: This model isn't mapped yet. model=deepseek-ai/DeepSeek-R1, custom_llm_provider=deepinfra. Add it here - 
https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
```

We should just check explicitly if the model exists in the litellm's cost map instead of try-catching like this.