### PR TITLE
add `curator` tag to hf_card_template

### DIFF
--- a/src/bespokelabs/curator/hf_card_template.py
+++ b/src/bespokelabs/curator/hf_card_template.py
@@ -2,6 +2,7 @@ HUGGINGFACE_CARD_TEMPLATE = """
 ---
 language: en
 license: mit
+tag: curator
 ---
 
 <a href="https://github.com/bespokelabsai/curator/">


### PR DESCRIPTION
For discoverability on the Hugging Face Hub, it would be nice to have usage of a `curator` tag. This will make it easier to track what people are building with this library i.e. something similar to: https://huggingface.co/datasets?library=library:distilabel&sort=trending