### PR TITLE
fix: Rich error log overlap by progress bar fix

### DIFF
--- a/examples/providers/klusterai_online.py
+++ b/examples/providers/klusterai_online.py
@@ -7,5 +7,5 @@ print(response["response"])
 
 llm = curator.LLM(model_name="deepseek-ai/DeepSeek-R1", backend="klusterai", backend_params={"max_retries": 1})
 
-response = llm("What is the capital of Italy?")
+response = llm(["What is the capital of Italy?"] * 100)
 print(response["response"])

--- a/examples/providers/klusterai_online.py
+++ b/examples/providers/klusterai_online.py
@@ -7,5 +7,5 @@ print(response["response"])
 
 llm = curator.LLM(model_name="deepseek-ai/DeepSeek-R1", backend="klusterai", backend_params={"max_retries": 1})
 
-response = llm(["What is the capital of Italy?"] * 100)
+response = llm(["What is the capital of Italy?"])
 print(response["response"])

--- a/examples/providers/klusterai_online.py
+++ b/examples/providers/klusterai_online.py
@@ -7,5 +7,5 @@ print(response["response"])
 
 llm = curator.LLM(model_name="deepseek-ai/DeepSeek-R1", backend="klusterai", backend_params={"max_retries": 1})
 
-response = llm(["What is the capital of Italy?"])
+response = llm("What is the capital of Italy?")
 print(response["response"])

--- a/src/bespokelabs/__init__.py
+++ b/src/bespokelabs/__init__.py
@@ -1,11 +1,1 @@
 """BespokeLabs Curator."""
-
-import logging
-
-logger = logging.getLogger("bespokelabs.curator")
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.WARNING)

--- a/src/bespokelabs/curator/__init__.py
+++ b/src/bespokelabs/curator/__init__.py
@@ -1,7 +1,19 @@
 """BespokeLabs Curator."""
 
+import logging
+
+from rich.console import Console
+from rich.logging import RichHandler
+
 from .code_executor.code_executor import CodeExecutor
 from .llm.llm import LLM
 from .types import prompt as types
 
 __all__ = ["LLM", "CodeExecutor", "types"]
+
+_CONSOLE = Console(stderr=True)
+logger = logging.getLogger("bespokelabs.curator")
+
+logger.setLevel(logging.WARNING)
+
+logger.addHandler(RichHandler(console=_CONSOLE))

--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -8,11 +8,11 @@ from pydantic import BaseModel, Field
 from rich import box
 from rich.console import Console, Group
 from rich.live import Live
-from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
+from bespokelabs.curator import _CONSOLE
 from bespokelabs.curator.telemetry.client import TelemetryEvent, telemetry_client
 from bespokelabs.curator.types.generic_batch import GenericBatch, GenericBatchStatus
 from bespokelabs.curator.types.generic_response import TokenUsage
@@ -55,10 +55,7 @@ class BatchStatusTracker(BaseModel):
 
     def start_tracker(self, console: Optional[Console] = None):
         """Start the progress tracker with rich console output."""
-        self._console = Console(stderr=True) if console is None else console
-
-        # Set up rich logging handler
-        logging.basicConfig(level=logging.WARNING, format="%(message)s", datefmt="[%Y-%m-%d %X]", handlers=[RichHandler(console=self._console)])
+        self._console = _CONSOLE if console is None else console
 
         # Create progress display
         self._progress = Progress(

--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -6,14 +6,12 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 from rich import box
-from rich.console import Console
+from rich.console import Console, Group
+from rich.live import Live
+from rich.logging import RichHandler
+from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.table import Table
-from rich.logging import RichHandler
-from rich.live import Live
-from rich.panel import Panel
-from rich.layout import Layout
-from rich.console import Group
 
 from bespokelabs.curator.telemetry.client import TelemetryEvent, telemetry_client
 from bespokelabs.curator.types.generic_batch import GenericBatch, GenericBatchStatus
@@ -58,15 +56,10 @@ class BatchStatusTracker(BaseModel):
     def start_tracker(self, console: Optional[Console] = None):
         """Start the progress tracker with rich console output."""
         self._console = Console(stderr=True) if console is None else console
-        
+
         # Set up rich logging handler
-        logging.basicConfig(
-            level=logging.WARNING,
-            format="%(message)s",
-            datefmt="[%Y-%m-%d %X]",
-            handlers=[RichHandler(console=self._console)]
-        )
-        
+        logging.basicConfig(level=logging.WARNING, format="%(message)s", datefmt="[%Y-%m-%d %X]", handlers=[RichHandler(console=self._console)])
+
         # Create progress display
         self._progress = Progress(
             TextColumn(
@@ -100,7 +93,7 @@ class BatchStatusTracker(BaseModel):
             cost_text="[bold white]Cost:[/bold white] [dim]--[/dim]",
             price_text="[bold white]Model Pricing:[/bold white] [dim]--[/dim]",
         )
-        
+
         # Create Live display that will show both logs and progress
         self._live = Live(
             Group(
@@ -108,13 +101,13 @@ class BatchStatusTracker(BaseModel):
             ),
             console=self._console,
             refresh_per_second=4,
-            transient=True  # This ensures logs stay above the progress bar
+            transient=True,  # This ensures logs stay above the progress bar
         )
         self._live.start()
 
     def stop_tracker(self):
         """Stop the tracker and display final statistics."""
-        if hasattr(self, '_live'):
+        if hasattr(self, "_live"):
             # Refresh one last time to show final state
             self._progress.refresh()
             # Stop the live display
@@ -133,7 +126,7 @@ class BatchStatusTracker(BaseModel):
 
     def __del__(self):
         """Ensure live display is stopped on deletion."""
-        if hasattr(self, '_live'):
+        if hasattr(self, "_live"):
             self._live.stop()
 
     def update_display(self):

--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -115,7 +115,12 @@ class BatchStatusTracker(BaseModel):
     def stop_tracker(self):
         """Stop the tracker and display final statistics."""
         if hasattr(self, '_live'):
+            # Refresh one last time to show final state
+            self._progress.refresh()
+            # Stop the live display
             self._live.stop()
+            # Print the final progress state
+            self._console.print(self._progress)
             self.display_final_stats()
 
         # update anonymized telemetry

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -11,11 +11,11 @@ from pydantic import BaseModel
 from rich import box
 from rich.console import Console, Group
 from rich.live import Live
-from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.table import Table
 
+from bespokelabs.curator import _CONSOLE
 from bespokelabs.curator.telemetry.client import TelemetryEvent, telemetry_client
 from bespokelabs.curator.types.generic_response import TokenUsage
 
@@ -98,10 +98,7 @@ class OnlineStatusTracker:
 
     def start_tracker(self, console: Optional[Console] = None):
         """Start the tracker."""
-        self._console = Console(stderr=True) if console is None else console
-
-        # Set up rich logging handler
-        logging.basicConfig(level=logging.WARNING, format="%(message)s", datefmt="[%Y-%m-%d %X]", handlers=[RichHandler(console=self._console)])
+        self._console = _CONSOLE if console is None else console
 
         # Create progress display
         self._progress = Progress(

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -255,7 +255,12 @@ class OnlineStatusTracker:
     def stop_tracker(self):
         """Stop the tracker."""
         if hasattr(self, '_live'):
+            # Refresh one last time to show final state
+            self._progress.refresh()
+            # Stop the live display
             self._live.stop()
+            # Print the final progress state
+            self._console.print(self._progress)
         
         table = Table(title="Final Curator Statistics", box=box.ROUNDED)
         table.add_column("Section/Metric", style="cyan")

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -141,6 +141,7 @@ class OnlineStatusTracker:
             rate_limit_text="[bold white]Rate Limits:[/bold white] [dim]--[/dim]",
             price_text="[bold white]Model Pricing:[/bold white] [dim]--[/dim]",
         )
+
         if self.model in model_cost:
             self.input_cost_per_million = model_cost[self.model]["input_cost_per_token"] * 1_000_000
             self.output_cost_per_million = model_cost[self.model]["output_cost_per_token"] * 1_000_000

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -10,11 +10,11 @@ from litellm import model_cost
 from pydantic import BaseModel
 from rich import box
 from rich.console import Console, Group
+from rich.live import Live
+from rich.logging import RichHandler
+from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.table import Table
-from rich.live import Live
-from rich.panel import Panel
-from rich.logging import RichHandler
 
 from bespokelabs.curator.telemetry.client import TelemetryEvent, telemetry_client
 from bespokelabs.curator.types.generic_response import TokenUsage
@@ -99,15 +99,10 @@ class OnlineStatusTracker:
     def start_tracker(self, console: Optional[Console] = None):
         """Start the tracker."""
         self._console = Console(stderr=True) if console is None else console
-        
+
         # Set up rich logging handler
-        logging.basicConfig(
-            level=logging.WARNING,
-            format="%(message)s",
-            datefmt="[%Y-%m-%d %X]",
-            handlers=[RichHandler(console=self._console)]
-        )
-        
+        logging.basicConfig(level=logging.WARNING, format="%(message)s", datefmt="[%Y-%m-%d %X]", handlers=[RichHandler(console=self._console)])
+
         # Create progress display
         self._progress = Progress(
             TextColumn(
@@ -128,7 +123,7 @@ class OnlineStatusTracker:
             TimeRemainingColumn(),
             console=self._console,
         )
-        
+
         # Add task
         self._task_id = self._progress.add_task(
             description=f"[cyan]Generating data using {self.model} with {self.token_limit_strategy.value} input and output token Strategy.",
@@ -158,7 +153,7 @@ class OnlineStatusTracker:
             ),
             console=self._console,
             refresh_per_second=4,
-            transient=True  # This ensures logs stay above the progress bar
+            transient=True,  # This ensures logs stay above the progress bar
         )
         self._live.start()
 
@@ -255,14 +250,14 @@ class OnlineStatusTracker:
 
     def stop_tracker(self):
         """Stop the tracker."""
-        if hasattr(self, '_live'):
+        if hasattr(self, "_live"):
             # Refresh one last time to show final state
             self._progress.refresh()
             # Stop the live display
             self._live.stop()
             # Print the final progress state
             self._console.print(self._progress)
-        
+
         table = Table(title="Final Curator Statistics", box=box.ROUNDED)
         table.add_column("Section/Metric", style="cyan")
         table.add_column("Value", style="yellow")
@@ -439,5 +434,5 @@ class OnlineStatusTracker:
 
     def __del__(self):
         """Ensure live display is stopped on deletion."""
-        if hasattr(self, '_live'):
+        if hasattr(self, "_live"):
             self._live.stop()


### PR DESCRIPTION
Addresses #432 
Addresses #458, credit @kartik4949 
- Add RichHandler for console logs for highlights
- Remove regular logs. 

Artificially add warning and error logs for demo purpose (on `examples/providers/klusterai_online.py`:

https://github.com/user-attachments/assets/80a08d8d-52fd-4412-b83e-a139e61d74fa

Run on `examples/poem-generation/poem.py`, (happy case):

https://github.com/user-attachments/assets/596a4983-ad8d-460d-9090-063ccdc124f0

