### PR TITLE
fix: handle empty response

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,27 @@
 [ English | <a href="README_zh.md">中文</a> ]
 </div>
 
-## 🎉 What's New 
+## NOTE: Using Curator with the DeepSeek API 
+The DeepSeek API is experiencing intermittent issues and will return empty responses during times of high traffic. We recommend
+calling the DeepSeek API through the `openai` backend, with a high max retries so that we can retry failed requests upon empty
+response and a reasonable max requests and tokens per minute so we don't retry too aggressively and overwhelm the API.
 
+```python
+llm = curator.LLM(
+    model_name="deepseek-reasoner",
+    generation_params={"temp": 0.0},
+    backend_params={
+        "max_requests_per_minute": 100,
+        "max_tokens_per_minute": 10_000_000,
+        "base_url": "https://api.deepseek.com/",
+        "api_key": <YOUR_DEEPSEEK_API_KEY>,
+        "max_retries": 50,
+    },
+    backend="openai",
+)
+```
+
+## 🎉 What's New 
 #### [2025.01.30] Batch Processing Support
 
 - [Batch Mode](https://www.bespokelabs.ai/blog/batch-processing-with-curator): Cut Token Costs in Half: 
@@ -46,8 +65,6 @@ llm = curator.LLM(
     backend_params={"max_retries": 1, "completion_window": "1h"},
 )
 ```
-
-
 
 ## Overview
 

--- a/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
@@ -81,7 +81,7 @@ class LiteLLMOnlineRequestProcessor(BaseOnlineRequestProcessor):
         """
         max_concurrent_requests = super().max_concurrent_requests
         if max_concurrent_requests is None and self._concurrency_only_rate_limited:
-            logging.info("Current provider implements concurrency only rate limit, " f"Using default concurrency of {self.default_max_concurrent_requests}")
+            logging.info(f"Current provider implements concurrency only rate limit, Using default concurrency of {self.default_max_concurrent_requests}")
             return self.default_max_concurrent_requests
         return max_concurrent_requests
 
@@ -335,9 +335,10 @@ class LiteLLMOnlineRequestProcessor(BaseOnlineRequestProcessor):
                     timeout=self.config.request_timeout,
                 )
                 response_message = response.model_dump() if hasattr(response, "model_dump") else response
-                response_message = response.model_dump() if hasattr(response, "model_dump") else response
             else:
                 completion_obj = await litellm.acompletion(**request.api_specific_request, timeout=self.config.request_timeout)
+                if completion_obj is None:
+                    raise Exception("Response is empty")
                 if self.config.return_completions_object:
                     response_message = dict(completion_obj)
                 else:

--- a/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
@@ -221,7 +221,9 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
         ) as response_obj:
             response = await response_obj.json()
 
-            if "error" in response:
+            if response is None:
+                raise Exception("Response is empty")
+            elif "error" in response:
                 status_tracker.num_api_errors += 1
                 error = response["error"]
                 error_message = error if isinstance(error, str) else error.get("message", "")


### PR DESCRIPTION
DeepSeek can return empty responses during times of high load:
https://api-docs.deepseek.com/quick_start/rate_limit.

"However, please note that when our servers are under high traffic pressure, your requests may take some time to receive a response from the server. During this period, your HTTP request will remain connected, and you may continuously receive contents in the following formats:

Non-streaming requests: Continuously return empty lines
Streaming requests: Continuously return SSE keep-alive comments (: keep-alive)
"

From empirically testing sometimes they just close the connection and return 200 with an empty response. We need to handle this gracefully by detecting when response is None and raise an Exception. This will trigger a retry instead of simply error-ing out.