### PR TITLE
Update README with better poem example, more news items, and more providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,46 +30,16 @@
 [ English | <a href="README_zh.md">中文</a> ]
 </div>
 
-## NOTE: Using Curator with the DeepSeek API 
-The DeepSeek API is experiencing intermittent issues and will return empty responses during times of high traffic. We recommend
-calling the DeepSeek API through the `openai` backend, with a high max retries so that we can retry failed requests upon empty
-response and a reasonable max requests and tokens per minute so we don't retry too aggressively and overwhelm the API.
-
-```python
-llm = curator.LLM(
-    model_name="deepseek-reasoner",
-    generation_params={"temp": 0.0},
-    backend_params={
-        "max_requests_per_minute": 100,
-        "max_tokens_per_minute": 10_000_000,
-        "base_url": "https://api.deepseek.com/",
-        "api_key": <YOUR_DEEPSEEK_API_KEY>,
-        "max_retries": 50,
-    },
-    backend="openai",
-)
-```
-
 ## 🎉 What's New 
 #### [2025.01.30] Batch Processing Support
 
-- [Batch Mode](https://www.bespokelabs.ai/blog/batch-processing-with-curator): Cut Token Costs in Half: 
+- [Batch Mode](https://www.bespokelabs.ai/blog/batch-processing-with-curator): Cut Token Costs in Half 🔥🔥🔥: 
   We’re launching Curator batch mode with support for OpenAI, Anthropic, and other compatible APIs. Through our partnership with kluster.ai, new users using Curator can access open-source models like DeepSeek-R1 and receive a **$25 credit** (limits apply). Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSeBeBKA_19ljeUCkpwkUuUL5YXUUPKUExpjmBaSfmF2XAhwVA/viewform?usp=dialog) to claim your credit.
-```python
-from bespokelabs import curator
 
-llm = curator.LLM(
-    model_name="deepseek-ai/DeepSeek-R1",
-    backend="klusterai",
-    batch=True,
-    backend_params={"max_retries": 1, "completion_window": "1h"},
-)
-```
 
 ## Overview
 
-
-Bespoke Curator makes it easy to create synthetic data pipelines. Whether you are training a model or extracting structure, Curator will prepare high-quality data quickly and robustly.
+Bespoke Curator makes it easy to create synthetic data pipelines. Whether you are training a model or extracting structured data, Curator will prepare high-quality data quickly and robustly.
 
 * Rich Python based library for generating and curating synthetic data.
 * Interactive viewer to monitor data while it is being generated.
@@ -81,13 +51,13 @@ Bespoke Curator makes it easy to create synthetic data pipelines. Whether you ar
 
 Check out our full documentation for [getting started](https://docs.bespokelabs.ai/bespoke-curator/getting-started), [tutorials](https://docs.bespokelabs.ai/bespoke-curator/tutorials), [guides](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides) and detailed [reference](https://docs.bespokelabs.ai/bespoke-curator/api-reference/llm-api-documentation).
 
-## Installation
+## 🛠️ Installation
 
 ```bash
 pip install bespokelabs-curator
 ```
 
-## Quickstart
+## 🚀 Quickstart
 
 ### Using `curator.LLM`
 
@@ -103,15 +73,6 @@ print(poem.to_pandas())
 > So now if you run the same prompt again, you will get the same response, pretty much instantly.
 > You can delete the cache at `~/.cache/curator` or disable it with `export CURATOR_DISABLE_CACHE=true`.
 
-### Calling other models
-You can also call other [LiteLLM](https://docs.litellm.ai/docs/) supported models by
-changing the `model_name` argument.
-
-```python
-llm = curator.LLM(model_name="claude-3-5-sonnet-20240620")
-```
-
-In addition to a wide range of API providers, local web servers (hosted by [vLLM](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#online-mode-server) or [Ollama](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-ollama-with-curator)) are supported via LiteLLM. For completely offline inference directly through vLLM, see the [documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#offline-mode-local).
 
 > [!IMPORTANT]
 > Make sure to set your API keys as environment variables for the model you are calling. For example running `export OPENAI_API_KEY=sk-...` and `export ANTHROPIC_API_KEY=ant-...` will allow you to run the previous two examples. A full list of supported models and their associated environment variable names can be found [in the litellm docs](https://docs.litellm.ai/docs/providers).
@@ -186,6 +147,7 @@ print(poem.to_pandas())
 2  Beauty of Bespoke Labs's Curator library  In the heart of Curation’s realm,  \nWhere art...
 3  Beauty of Bespoke Labs's Curator library  Step within the library’s embrace,  \nA sanctu...
 ```
+
 In the `Poet` class:
 * `response_format` is the structured output class we defined above.
 * `prompt` takes the input (`input`) and returns the prompt for the LLM.
@@ -202,6 +164,80 @@ for troubleshooting information.
 ### Anonymized Telemetry
 
 We collect minimal, anonymized usage telemetry to help prioritize new features and improvements that benefit the Curator community. You can opt out by setting the `TELEMETRY_ENABLED` environment variable to `False`. 
+
+## 📖 Providers
+Curator supports a wide range of providers, including OpenAI, Anthropic, and many more. 
+
+### LiteLLM (Gemini, together.ai, etc.)
+Here is an example of using Gemini with litellm backend ([docs reference]()):
+```python
+llm = curator.LLM(
+    model_name="gemini/gemini-1.5-flash",  # LiteLLM model identifier
+    backend="litellm",                      # Specify LiteLLM backend
+    backend_params={
+        "max_requests_per_minute": 2_000,   # Rate limit for requests
+        "max_tokens_per_minute": 4_000_000  # Token usage limit
+    },
+)
+```
+
+### Ollama
+Using Ollama backend ([docs reference](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-ollama-with-curator#id-2.-configure-the-ollama-backend)):
+```python
+llm = curator.LLM(
+    model_name="ollama/llama3.1:8b",  # Ollama model identifier
+    backend_params={"base_url": "http://localhost:11434"},  # Ollama instance
+)
+```
+
+### vLLM
+Using vLLM backend ([docs reference](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#id-3-initialize-and-use-the-generator)):
+
+```python
+llm = curator.LLM( 
+    model_name="Qwen/Qwen2.5-3B-Instruct", 
+    backend="vllm", 
+    backend_params={ 
+        "tensor_parallel_size": 1, # Adjust based on GPU count 
+        "gpu_memory_utilization": 0.7 
+    }
+)
+```
+### DeepSeek
+> [!IMPORTANT]
+> The DeepSeek API is experiencing intermittent issues and will return empty responses during times of high traffic. We recommend
+calling the DeepSeek API through the `openai` backend, with a high max retries so that we can retry failed requests upon empty
+response and a reasonable max requests and tokens per minute so we don't retry too aggressively and overwhelm the API.
+
+```python
+llm = curator.LLM(
+    model_name="deepseek-reasoner",
+    generation_params={"temp": 0.0},
+    backend_params={
+        "max_requests_per_minute": 100,
+        "max_tokens_per_minute": 10_000_000,
+        "base_url": "https://api.deepseek.com/",
+        "api_key": <YOUR_DEEPSEEK_API_KEY>,
+        "max_retries": 50,
+    },
+    backend="openai",
+)
+```
+## Batch Mode
+```python
+from bespokelabs import curator
+
+llm = curator.LLM(
+    model_name="deepseek-ai/DeepSeek-R1",
+    backend="klusterai",
+    batch=True,
+    backend_params={"max_retries": 1, "completion_window": "1h"},
+)
+```
+See documentation
+* [OpenAI batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-openai-for-batch-inference)
+* [Anthropic batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-anthropic-for-batch-inference)
+* [kluster.ai batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-kluster.ai-for-batch-inference)
 
 ## Bespoke Curator Viewer
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ llm = curator.LLM(
 )
 ```
 [Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-litellm-for-diverse-providers)
+
 ### Ollama
 ```python
 llm = curator.LLM(
@@ -217,6 +218,7 @@ llm = curator.LLM(
 ```
 [Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#id-3-initialize-and-use-the-generator)
 ### DeepSeek
+DeepSeek offers an OpenAI-compatible API that you can use with the `openai` backend.
 > [!IMPORTANT]
 > The DeepSeek API is experiencing intermittent issues and will return empty responses during times of high traffic. We recommend
 calling the DeepSeek API through the `openai` backend, with a high max retries so that we can retry failed requests upon empty
@@ -238,13 +240,13 @@ llm = curator.LLM(
 ```
 
 ### kluster.ai
-[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-kluster.ai-for-batch-inference)
 ```python
 llm = curator.LLM(
     model_name="deepseek-ai/DeepSeek-R1", 
     backend="klusterai",
 )
 ```
+[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-kluster.ai-for-batch-inference)
 ## 📦 Batch Mode
 Several providers offer about 50% discount on token usage when using batch mode. Curator makes it easy to use batch mode with a wide range of providers.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ print(poems.to_pandas())
 ```
 Output:
 ```
-    title       	    		poem
+    title                           poem
 0   Dreams of a Robot: Awakening    In circuits deep, where silence hums, \nA dre..
 1   Life of an AI Agent - Poem 1    In circuits woven, thoughts ignite,\nI dwell i...
 ```
@@ -141,7 +141,7 @@ poems = poet(topics)
 ```
 Output:
 ```
- 	title	    		  poem
+ 	title                     poem
 0	The Language of Algebra	  In symbols and signs, truths intertwine,..
 1	The Geometry of Space	  In the world around us, shapes do collide,..
 2	The Language of Logic	  In circuits and wires where silence speaks,..

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ llm = curator.LLM(model_name="gpt-4o-mini")
 poem = llm("Write a poem about the importance of data in AI.")
 print(poem.to_pandas())
 ```
-
 > [!NOTE]
 > Retries and caching are enabled by default to help you rapidly iterate your data pipelines.
 > So now if you run the same prompt again, you will get the same response, pretty much instantly.
@@ -77,37 +76,15 @@ print(poem.to_pandas())
 > [!IMPORTANT]
 > Make sure to set your API keys as environment variables for the model you are calling. For example running `export OPENAI_API_KEY=sk-...` and `export ANTHROPIC_API_KEY=ant-...` will allow you to run the previous two examples. A full list of supported models and their associated environment variable names can be found [in the litellm docs](https://docs.litellm.ai/docs/providers).
 
+You can also send a list of prompts to the LLM, or a HuggingFace Dataset object (see below for more details).
+
 > [!TIP]
 > If you are generating large datasets, you may want to use [batch mode](https://docs.bespokelabs.ai/bespoke-curator/tutorials/save-usdusdusd-with-batch-mode) to save costs. Currently batch APIs from [OpenAI](https://platform.openai.com/docs/guides/batch) and [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/message-batches) are supported. With curator this is as simple as setting `batch=True` in the `LLM` class.
 
-### Using structured outputs
+### Using structured outputs and custom prompting and parsing logic
 
 Let's use structured outputs to generate multiple poems in a single LLM call. We can define a class to encapsulate a list of poems,
 and then pass it to the `LLM` class.
-
-```python
-from typing import List
-from pydantic import BaseModel, Field
-from bespokelabs import curator
-
-class Poem(BaseModel):
-    poem: str = Field(description="A poem.")
-
-
-class Poems(BaseModel):
-    poems_list: List[Poem] = Field(description="A list of poems.")
-
-
-llm = curator.LLM(model_name="gpt-4o-mini", response_format=Poems)
-poems = llm(["Write two poems about the importance of data in AI.", 
-              "Write three haikus about the importance of data in AI."])
-print(poems.to_pandas())
-```
-
-Note how each `Poems` object occupies a single row in the dataset. 
-
-
-For more advanced use cases, you might need to define more custom parsing and prompting logic. For example, you might want to preserve the mapping between each topic and the poem being generated from it. In this case, you can define a `Poet` object that inherits from `LLM`, and define your own prompting and parsing logic:
 
 ```python
 from typing import Dict, List
@@ -172,11 +149,11 @@ Curator supports a wide range of providers, including OpenAI, Anthropic, and man
 Here is an example of using Gemini with litellm backend ([docs reference]()):
 ```python
 llm = curator.LLM(
-    model_name="gemini/gemini-1.5-flash",  # LiteLLM model identifier
-    backend="litellm",                      # Specify LiteLLM backend
+    model_name="gemini/gemini-1.5-flash",
+    backend="litellm",
     backend_params={
-        "max_requests_per_minute": 2_000,   # Rate limit for requests
-        "max_tokens_per_minute": 4_000_000  # Token usage limit
+        "max_requests_per_minute": 2_000,
+        "max_tokens_per_minute": 4_000_000
     },
 )
 ```
@@ -223,18 +200,15 @@ llm = curator.LLM(
     backend="openai",
 )
 ```
-## Batch Mode
-```python
-from bespokelabs import curator
+## 📦 Batch Mode
+Several providers offer about 50% discount on token usage when using batch mode. Curator makes it easy to use batch mode with a wide range of providers.
 
-llm = curator.LLM(
-    model_name="deepseek-ai/DeepSeek-R1",
-    backend="klusterai",
-    batch=True,
-    backend_params={"max_retries": 1, "completion_window": "1h"},
-)
+Example with OpenAI ([docs reference](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-openai-for-batch-inference)):
+```python
+llm = curator.LLM(model_name="gpt-4o-mini", batch=True)
 ```
-See documentation
+
+See documentation:
 * [OpenAI batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-openai-for-batch-inference)
 * [Anthropic batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-anthropic-for-batch-inference)
 * [kluster.ai batch mode](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-kluster.ai-for-batch-inference)

--- a/README.md
+++ b/README.md
@@ -162,8 +162,27 @@ We collect minimal, anonymized usage telemetry to help prioritize new features a
 ## 📖 Providers
 Curator supports a wide range of providers, including OpenAI, Anthropic, and many more. 
 
-### LiteLLM (Gemini, together.ai, etc.)
-Here is an example of using Gemini with litellm backend ([docs reference]()):
+### OpenAI backend
+```python
+llm = curator.LLM(
+    model_name="gpt-4o-mini",
+)
+```
+For other models that support OpenAI-compatible APIs, you can use the `openai` backend:
+```python
+llm = curator.LLM(
+    model_name="gpt-4o-mini",
+    backend="openai",
+    backend_params={
+        "base_url": "https://your-openai-compatible-api-url",
+        "api_key": <YOUR_OPENAI_COMPATIBLE_SERVICE_API_KEY>,
+    },
+)
+```
+
+
+### LiteLLM (Anthropic, Gemini, together.ai, etc.)
+Here is an example of using Gemini with litellm backend:
 ```python
 llm = curator.LLM(
     model_name="gemini/gemini-1.5-flash",
@@ -174,18 +193,17 @@ llm = curator.LLM(
     },
 )
 ```
-
+[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-litellm-for-diverse-providers)
 ### Ollama
-Using Ollama backend ([docs reference](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-ollama-with-curator#id-2.-configure-the-ollama-backend)):
 ```python
 llm = curator.LLM(
     model_name="ollama/llama3.1:8b",  # Ollama model identifier
-    backend_params={"base_url": "http://localhost:11434"},  # Ollama instance
+    backend_params={"base_url": "http://localhost:11434"},
 )
 ```
+[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-ollama-with-curator#id-2.-configure-the-ollama-backend)
 
 ### vLLM
-Using vLLM backend ([docs reference](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#id-3-initialize-and-use-the-generator)):
 
 ```python
 llm = curator.LLM( 
@@ -197,6 +215,7 @@ llm = curator.LLM(
     }
 )
 ```
+[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-vllm-with-curator#id-3-initialize-and-use-the-generator)
 ### DeepSeek
 > [!IMPORTANT]
 > The DeepSeek API is experiencing intermittent issues and will return empty responses during times of high traffic. We recommend
@@ -215,6 +234,15 @@ llm = curator.LLM(
         "max_retries": 50,
     },
     backend="openai",
+)
+```
+
+### kluster.ai
+[Documentation](https://docs.bespokelabs.ai/bespoke-curator/how-to-guides/using-kluster.ai-for-batch-inference)
+```python
+llm = curator.LLM(
+    model_name="deepseek-ai/DeepSeek-R1", 
+    backend="klusterai",
 )
 ```
 ## 📦 Batch Mode

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ topics = Dataset.from_dict({'topic': ['Dreams of a Robot']})
 poems = poet(topics)
 print(poems.to_pandas())
 ```
-
+Output:
 ```
-    title	    		            poem
+    title       	    		    poem
 0   Dreams of a Robot: Awakening    In circuits deep, where silence hums, \nA dre..
 1   Life of an AI Agent - Poem 1    In circuits woven, thoughts ignite,\nI dwell i...
-
+```
 
 In the `Poet` class:
 * `response_format` is the structured output class we defined above.
@@ -139,7 +139,7 @@ topic_generator = TopicGenerator(model_name="gpt-4o-mini")
 topics = topic_generator("Mathematics")
 poems = poet(topics)
 ```
-
+Output:
 ```
  	title	    		      poem
 0	The Language of Algebra	  In symbols and signs, truths intertwine,..

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@
 </div>
 
 ## 🎉 What's New 
-#### [2025.01.30] Batch Processing Support
-
-- [Batch Mode](https://www.bespokelabs.ai/blog/batch-processing-with-curator): Cut Token Costs in Half 🔥🔥🔥: 
-  We’re launching Curator batch mode with support for OpenAI, Anthropic, and other compatible APIs. Through our partnership with kluster.ai, new users using Curator can access open-source models like DeepSeek-R1 and receive a **$25 credit** (limits apply). Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSeBeBKA_19ljeUCkpwkUuUL5YXUUPKUExpjmBaSfmF2XAhwVA/viewform?usp=dialog) to claim your credit.
-
+* **[2025.01.30]** [Batch Processing Support for OpenAI, Anthropic, and other compatible APIs](https://www.bespokelabs.ai/blog/batch-processing-with-curator): Cut Token Costs in Half 🔥🔥🔥. Through our partnership with kluster.ai, new users using Curator can access open-source models like DeepSeek-R1 and receive a **$25 credit** (limits apply). Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSeBeBKA_19ljeUCkpwkUuUL5YXUUPKUExpjmBaSfmF2XAhwVA/viewform?usp=dialog) to claim your credit.
+* **[2025.01.27]** We used Bespoke-Curator was used to create [OpenThoughts-117k](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k), a high-quality reasoning dataset (trending on HuggingFace).
+* **[2025.01.22]** Curator was used to create [Bespoke-Stratos-17k](https://huggingface.co/datasets/bespokelabs/Bespoke-Stratos-17k), a high-quality reasoning dataset (trending on HuggingFace).
+* **[2025.01.15]** Curator launched 🎉
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ print(poems.to_pandas())
 ```
 Output:
 ```
-    title       	    		    poem
+    title       	    		poem
 0   Dreams of a Robot: Awakening    In circuits deep, where silence hums, \nA dre..
 1   Life of an AI Agent - Poem 1    In circuits woven, thoughts ignite,\nI dwell i...
 ```
@@ -141,7 +141,7 @@ poems = poet(topics)
 ```
 Output:
 ```
- 	title	    		      poem
+ 	title	    		  poem
 0	The Language of Algebra	  In symbols and signs, truths intertwine,..
 1	The Geometry of Space	  In the world around us, shapes do collide,..
 2	The Language of Logic	  In circuits and wires where silence speaks,..


### PR DESCRIPTION
Update the poem example:
1. In the first part, make it clear that you can use dataset object to create an input for the poet object (This was confusing for Liyan).
2. The second part illustrates chaining for increased diversity (This was a bit unclear/confusing for a client).

Other changes:
1. Added a list of providers
2. Moved batch example down
3. Added more news items.
