### PR TITLE
feat: add param to disable metadata db

### DIFF
--- a/src/bespokelabs/curator/code_executor/code_executor.py
+++ b/src/bespokelabs/curator/code_executor/code_executor.py
@@ -135,19 +135,20 @@ class CodeExecutor:
         fingerprint = self._hash_fingerprint(dataset_hash, disable_cache)
 
         # Initialize and store metadata
-        metadata_db_path = os.path.join(curator_cache_dir, "metadata.db")
-        metadata_db = CodeMetadataDB(metadata_db_path)
+        if self._code_executor.config.use_metadata_db:
+            metadata_db_path = os.path.join(curator_cache_dir, "metadata.db")
+            metadata_db = CodeMetadataDB(metadata_db_path)
 
-        metadata_dict = {
-            "timestamp": datetime.now().isoformat(),
-            "dataset_hash": dataset_hash,
-            "code": _get_function_source(self.code),
-            "code_input": _get_function_source(self.code_input),
-            "code_output": _get_function_source(self.code_output),
-            "run_hash": fingerprint,
-        }
+            metadata_dict = {
+                "timestamp": datetime.now().isoformat(),
+                "dataset_hash": dataset_hash,
+                "code": _get_function_source(self.code),
+                "code_input": _get_function_source(self.code_input),
+                "code_output": _get_function_source(self.code_output),
+                "run_hash": fingerprint,
+            }
 
-        metadata_db.store_metadata(metadata_dict)
+            metadata_db.store_metadata(metadata_dict)
 
         # Set up run-specific cache directory
         run_cache_dir = os.path.join(curator_cache_dir, fingerprint)

--- a/src/bespokelabs/curator/code_executor/types.py
+++ b/src/bespokelabs/curator/code_executor/types.py
@@ -64,6 +64,7 @@ class CodeExecutionResponse(BaseModel):
 class CodeExecutionBackendConfig(BaseModel):
     """Configuration for the code execution backend."""
 
+    use_metadata_db: bool = True
     max_requests_per_minute: int = 10000
     max_retries: int = 3
     seconds_to_pause_on_rate_limit: int = 10


### PR DESCRIPTION
Running multiple CodeExecutor instances at once errors out writes to metadata DB because SqLite implementation doesn't support concurrency. 

Added a param in `backend_params` to disable writes to the db. Example usage: 

```python
hello_executor = HelloExecutor(backend_params={'use_metadata_db': False})
```