### PR TITLE
bug: wrap estimate tokens with int in litellm backend and mime type fix.

### DIFF
--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -139,6 +139,7 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
 
         def _format_multimodal(data, mime_type="image/png"):
             """Format multimodal prompt data for API request."""
+            mime_type = mime_type or "image/png"
             if data.url and not data.is_local:
                 return {"type": "image_url", "image_url": {"url": data.url}}
             else:

--- a/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/litellm_online_request_processor.py
@@ -208,7 +208,7 @@ class LiteLLMOnlineRequestProcessor(BaseOnlineRequestProcessor):
             _TokenUsage: Total estimated tokens (input and output)
         """
         input_tokens = litellm.token_counter(model=self.config.model, messages=messages)
-        output_tokens = self.estimate_output_tokens()
+        output_tokens = int(self.estimate_output_tokens())
         return _TokenUsage(input=input_tokens, output=output_tokens)
 
     def test_call(self):

--- a/src/bespokelabs/curator/types/prompt.py
+++ b/src/bespokelabs/curator/types/prompt.py
@@ -52,7 +52,7 @@ class Image(BaseType):
     content: bytes | PIL_Image.Image | str = Field("", description="Image content bytes.")
     detail: str = Field("auto", description="Details about the image. Note 'auto' is only supported for OpenAI client.")
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    mime_type: str | None = Field("image/png", description="The MIME type of the file.")
+    mime_type: str | None = Field(None, description="The MIME type of the file.")
 
     type: t.ClassVar[str] = "image"
 


### PR DESCRIPTION
- Fix None Mime type bug in Image types in curator.
- Wrap estimate tokens with int in case of float numbers.