### PR TITLE
Ensure that when a list or a string is passed without a dictionary, we handle it appropriately.

### DIFF
--- a/src/bespokelabs/curator/code_executor/code_execution_backend/base_backend.py
+++ b/src/bespokelabs/curator/code_executor/code_execution_backend/base_backend.py
@@ -18,15 +18,13 @@ from pydantic import BaseModel, ValidationError
 from bespokelabs.curator.code_executor.code_formatter import CodeFormatter
 from bespokelabs.curator.code_executor.tracker import CodeExecutionStatusTracker
 from bespokelabs.curator.code_executor.types import CodeAPIRequest, CodeExecutionOutput, CodeExecutionRequest, CodeExecutionResponse
+from bespokelabs.curator.constants import _CACHE_MSG
 from bespokelabs.curator.file_utilities import count_lines
 from bespokelabs.curator.log import logger
 from bespokelabs.curator.request_processor.event_loop import run_in_event_loop
 
 if TYPE_CHECKING:
     from datasets import Dataset
-
-
-CACHE_MSG = "If you want to regenerate the dataset, disable or delete the cache."
 
 
 class BaseCodeExecutionBackend:
@@ -363,7 +361,7 @@ class BaseCodeExecutionBackend:
         incomplete_files = self._verify_existing_request_files(dataset)
 
         if len(incomplete_files) == 0:
-            logger.info(f"Using cached requests. {CACHE_MSG}")
+            logger.info(f"Using cached requests. {_CACHE_MSG}")
             # count existing jobs in file and print first job
             with open(request_files[0], "r") as f:
                 # Count lines and store first job
@@ -440,7 +438,7 @@ class BaseCodeExecutionBackend:
         if os.path.exists(dataset_file):
             logger.debug(f"Loading dataset from {dataset_file}")
             try:
-                logger.info(f"Using cached output dataset. {CACHE_MSG}")
+                logger.info(f"Using cached output dataset. {_CACHE_MSG}")
                 return self._load_from_dataset_file(dataset_file)
             except pyarrow.lib.ArrowInvalid:
                 os.remove(dataset_file)

--- a/src/bespokelabs/curator/constants.py
+++ b/src/bespokelabs/curator/constants.py
@@ -6,3 +6,9 @@ _DEFAULT_CACHE_DIR = "~/.cache"
 BASE_CLIENT_URL = "https://api.bespokelabs.ai/v0/viewer"
 PUBLIC_CURATOR_VIEWER_HOME_URL = "https://curator.bespokelabs.ai"
 PUBLIC_CURATOR_VIEWER_DATASET_URL = PUBLIC_CURATOR_VIEWER_HOME_URL + "/datasets"
+_INTERNAL_PROMPT_KEY = "__internal_prompt"
+_CACHE_MSG = (
+    "If you want to regenerate the dataset, disable or delete the cache.\n See "
+    "https://docs.bespokelabs.ai/bespoke-curator/tutorials/automatic-recovery-and-caching#disable-caching "
+    "for more information."
+)

--- a/src/bespokelabs/curator/llm/llm.py
+++ b/src/bespokelabs/curator/llm/llm.py
@@ -48,6 +48,9 @@ class LLM:
             The list [{"role": "user", "content": "Write a poem about love"},
             {"role": "assistant", "content": "Here is a poem about love"}]
         """
+        # Check for prompt__internal first, which is our internal key
+        if "prompt__internal" in input:
+            return input["prompt__internal"]
         return input["prompt"]
 
     def parse(self, input: _DictOrBaseModel, response: _DictOrBaseModel) -> _DictOrBaseModel:
@@ -60,11 +63,22 @@ class LLM:
         Returns:
             The parsed output row that combines the input and response,
         """
+        # Create a modified input without prompt__internal
+        cleaned_input = {}
+        if isinstance(input, dict):
+            cleaned_input = {k: v for k, v in input.items() if k != "prompt__internal"}
+        # Process the response
         if isinstance(response, str):
-            return {"response": response}
+            result = {"response": response}
         elif isinstance(response, BaseModel):
-            return response.model_dump()
-        return response
+            result = response.model_dump()
+        else:
+            result = response
+        # Combine cleaned input with result if needed
+        if cleaned_input:
+            if isinstance(result, dict):
+                result = {**cleaned_input, **result}
+        return result
 
     def __init__(
         self,
@@ -330,16 +344,17 @@ def _convert_to_dataset(iterable: Iterable) -> "Dataset":
     """Convert an iterable to a Dataset.
 
     The prompt is expected to be a prompt string or a list of messages.
+    It will be stored with the key 'prompt__internal' internally.
     """
     if isinstance(iterable, str) or _is_message_list(iterable):
         # A single string or list of messages is converted to a dataset with a single row
-        dataset = Dataset.from_list([{"prompt": iterable}])
+        dataset = Dataset.from_list([{"prompt__internal": iterable}])
     elif not isinstance(iterable, Dataset) and iterable is not None:
         # Wrap the iterable in a generator, the prompt is expected to be a prompt string or a list of messages
         def wrapped_iterable():
             for input in iterable:
                 if isinstance(input, str) or _is_message_list(input):
-                    yield {"prompt": input}
+                    yield {"prompt__internal": input}
                 else:
                     yield input
 

--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -15,6 +15,7 @@ import aiofiles
 import pyarrow
 from pydantic import BaseModel, ValidationError
 
+from bespokelabs.curator.constants import _CACHE_MSG
 from bespokelabs.curator.cost import cost_processor_factory
 from bespokelabs.curator.file_utilities import count_lines
 from bespokelabs.curator.hf_card_template import HUGGINGFACE_CARD_TEMPLATE
@@ -26,9 +27,6 @@ from bespokelabs.curator.types.generic_response import GenericResponse
 
 if TYPE_CHECKING:
     from datasets import Dataset
-
-
-CACHE_MSG = "If you want to regenerate the dataset, disable or delete the cache."
 
 
 class BaseRequestProcessor(ABC):
@@ -210,7 +208,7 @@ class BaseRequestProcessor(ABC):
         incomplete_files = self._verify_existing_request_files(dataset)
 
         if len(incomplete_files) == 0:
-            logger.info(f"Using cached requests. {CACHE_MSG}")
+            logger.info(f"Using cached requests. {_CACHE_MSG}")
             # count existing jobs in file and print first job
             with open(request_files[0], "r") as f:
                 # Count lines and store first job
@@ -326,7 +324,7 @@ class BaseRequestProcessor(ABC):
         if os.path.exists(dataset_file):
             logger.debug(f"Loading dataset from {dataset_file}")
             try:
-                logger.info(f"Using cached output dataset. {CACHE_MSG}")
+                logger.info(f"Using cached output dataset. {_CACHE_MSG}")
                 return self._load_from_dataset_file(dataset_file)
             except pyarrow.lib.ArrowInvalid:
                 os.remove(dataset_file)

--- a/tests/integrations/test_all.py
+++ b/tests/integrations/test_all.py
@@ -186,13 +186,13 @@ def test_basic_cache(caplog, temp_working_dir, mock_dataset):
         distilled_dataset = helper.create_basic(temp_working_dir, mock_dataset)
 
         # This should use cache
-        from bespokelabs.curator.request_processor.base_request_processor import CACHE_MSG
+        from bespokelabs.curator.constants import _CACHE_MSG
 
         logger = "bespokelabs.curator.request_processor.base_request_processor"
         with caplog.at_level(logging.INFO, logger=logger):
             helper.create_basic(temp_working_dir, mock_dataset)
             distilled_dataset.cleanup_cache_files()
-            assert f"Using cached output dataset. {CACHE_MSG}" in caplog.text
+            assert f"Using cached output dataset. {_CACHE_MSG}" in caplog.text
 
 
 @pytest.mark.parametrize("temp_working_dir", ([{"integration": "openai"}]), indirect=True)

--- a/tests/unittests/test_caching.py
+++ b/tests/unittests/test_caching.py
@@ -32,7 +32,7 @@ def test_same_dataset_caching(tmp_path, temp_working_dir):
     _, _, vcr_config = temp_working_dir
 
     with vcr_config.use_cassette("basic_diff_cache.yaml"):
-        dataset = Dataset.from_list([{"prompt": "Say '1'. Do not explain."}])
+        dataset = ["Say '1'. Do not explain."]
         prompter = curator.LLM(model_name="gpt-4o-mini")
 
         result = prompter(dataset, working_dir=str(tmp_path))
@@ -52,9 +52,14 @@ def test_different_dataset_caching(tmp_path, temp_working_dir):
     _, _, vcr_config = temp_working_dir
 
     with vcr_config.use_cassette("basic_diff_cache.yaml"):
-        dataset1 = Dataset.from_list([{"prompt": "Say '1'. Do not explain."}])
-        dataset2 = Dataset.from_list([{"prompt": "Say '2'. Do not explain."}])
-        prompter = curator.LLM(model_name="gpt-4o-mini")
+        dataset1 = Dataset.from_list([{"my_prompt": "Say '1'. Do not explain."}])
+        dataset2 = Dataset.from_list([{"my_prompt": "Say '2'. Do not explain."}])
+
+        class Prompter(curator.LLM):
+            def prompt(self, input: str):
+                return input["my_prompt"]
+
+        prompter = Prompter(model_name="gpt-4o-mini")
 
         result = prompter(dataset1, working_dir=str(tmp_path))
         assert result.to_pandas().iloc[0]["response"] == "1"

--- a/tests/unittests/test_dataset_conversion.py
+++ b/tests/unittests/test_dataset_conversion.py
@@ -27,10 +27,10 @@ def test_is_message_list(single_message, conversation, conversation_with_system)
 
 
 def test_convert_to_dataset(single_message, conversation, conversation_with_system):
-    assert _convert_to_dataset("test").to_list() == [{"prompt": "test"}]
-    assert _convert_to_dataset(single_message).to_list() == [{"prompt": single_message}]
-    assert _convert_to_dataset(conversation).to_list() == [{"prompt": conversation}]
-    assert _convert_to_dataset(conversation_with_system).to_list() == [{"prompt": conversation_with_system}]
-    assert _convert_to_dataset([conversation, conversation_with_system]).to_list() == [{"prompt": conversation}, {"prompt": conversation_with_system}]
+    assert _convert_to_dataset("test").to_list() == [{"prompt__internal": "test"}]
+    assert _convert_to_dataset(single_message).to_list() == [{"prompt__internal": single_message}]
+    assert _convert_to_dataset(conversation).to_list() == [{"prompt__internal": conversation}]
+    assert _convert_to_dataset(conversation_with_system).to_list() == [{"prompt__internal": conversation_with_system}]
+    assert _convert_to_dataset([conversation, conversation_with_system]).to_list() == [{"prompt__internal": conversation}, {"prompt__internal": conversation_with_system}]
     assert _convert_to_dataset(Dataset.from_list([{"prompt": "test"}])).to_list() == [{"prompt": "test"}]
     assert _convert_to_dataset([{"prompt": "test"}]).to_list() == [{"prompt": "test"}]

--- a/tests/unittests/test_dataset_conversion.py
+++ b/tests/unittests/test_dataset_conversion.py
@@ -1,6 +1,7 @@
 import pytest
 from datasets import Dataset
 
+from bespokelabs.curator.constants import _INTERNAL_PROMPT_KEY
 from bespokelabs.curator.llm.llm import _convert_to_dataset, _is_message_list
 
 
@@ -27,10 +28,13 @@ def test_is_message_list(single_message, conversation, conversation_with_system)
 
 
 def test_convert_to_dataset(single_message, conversation, conversation_with_system):
-    assert _convert_to_dataset("test").to_list() == [{"prompt__internal": "test"}]
-    assert _convert_to_dataset(single_message).to_list() == [{"prompt__internal": single_message}]
-    assert _convert_to_dataset(conversation).to_list() == [{"prompt__internal": conversation}]
-    assert _convert_to_dataset(conversation_with_system).to_list() == [{"prompt__internal": conversation_with_system}]
-    assert _convert_to_dataset([conversation, conversation_with_system]).to_list() == [{"prompt__internal": conversation}, {"prompt__internal": conversation_with_system}]
+    assert _convert_to_dataset("test").to_list() == [{_INTERNAL_PROMPT_KEY: "test"}]
+    assert _convert_to_dataset(single_message).to_list() == [{_INTERNAL_PROMPT_KEY: single_message}]
+    assert _convert_to_dataset(conversation).to_list() == [{_INTERNAL_PROMPT_KEY: conversation}]
+    assert _convert_to_dataset(conversation_with_system).to_list() == [{_INTERNAL_PROMPT_KEY: conversation_with_system}]
+    assert _convert_to_dataset([conversation, conversation_with_system]).to_list() == [
+        {_INTERNAL_PROMPT_KEY: conversation},
+        {_INTERNAL_PROMPT_KEY: conversation_with_system},
+    ]
     assert _convert_to_dataset(Dataset.from_list([{"prompt": "test"}])).to_list() == [{"prompt": "test"}]
-    assert _convert_to_dataset([{"prompt": "test"}]).to_list() == [{"prompt": "test"}]
+    assert _convert_to_dataset([{"new_prompt": "test"}]).to_list() == [{"new_prompt": "test"}]


### PR DESCRIPTION
Earlier, we would create a dictionary with a key "prompt".
This was causing some of the prompts to be rendered dictionaries rather than strings.

Also a few other changes:
1. Put CACHE_MSG in constants.py 
2. And add a link to our docs in CACHE_MSG. Simply saying "delete cache" is not helpful.