### PR TITLE
fix: output unicode directly for gemini batch processor

### DIFF
--- a/src/bespokelabs/curator/request_processor/batch/gemini_batch_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/batch/gemini_batch_request_processor.py
@@ -335,7 +335,7 @@ class GeminiBatchRequestProcessor(BaseBatchRequestProcessor):
         try:
             blob_name = f"batch_requests/{filename}"
             blob = self._bucket.blob(blob_name)
-            jsonl_data = "\n".join(json.dumps(item) for item in requests)
+            jsonl_data = "\n".join(json.dumps(item, ensure_ascii=False) for item in requests)
             blob.upload_from_string(jsonl_data, content_type="application/jsonl+json")
         except Exception as e:
             logger.error(f"Could not upload batch file request to gcloud at {gcs_path} :: reason {e}")


### PR DESCRIPTION
By default, json.dumps() will convert Unicode characters to ASCII string for writing to files, so "😄" -> "\ud83d\ude04"

However, it seems like Gemini batch does not parse the "\ud83d\ude04" correctly (something to do with surrogates), leading to corrupt emoji character. For Gemini, we will specifically output the JSON as unicode instead of ASCII.

Before bug fix: https://curator.bespokelabs.ai/datasets/85bbe23ee65648c6b4c59a0bedca82c1?page=1&row=0
After bug fix: https://curator.bespokelabs.ai/datasets/321afc14d1934bc78348b41a9a422fb4

I will leave other backends unchanged since this only seems to affect Gemini batch specifically. Other backends seem fine from my tests:
- LiteLLM: https://curator.bespokelabs.ai/datasets/a7b7a71640374821b3eb0622f950e9ae
- OpenAI batch: https://curator.bespokelabs.ai/datasets/ceadadcb38134f50b7751241ae36637d
- Anthropic: https://curator.bespokelabs.ai/datasets/6f8a4e66091c4f86ab6eeb921182c4a3?page=1&row=0
- Anthropic batch: https://curator.bespokelabs.ai/datasets/e8d07716ab3b48a1a280197214416f5b?page=1&row=0
- OpenAI: https://curator.bespokelabs.ai/datasets/dbfa65d6231a438b8d44d2b69498da82
