### PR TITLE
Fix/live colab display error

### DIFF
--- a/src/bespokelabs/curator/request_processor/event_loop.py
+++ b/src/bespokelabs/curator/request_processor/event_loop.py
@@ -1,10 +1,31 @@
 import asyncio
 
 import nest_asyncio
+from rich.console import Console
+from rich.live import Live
 
 
 def run_in_event_loop(coroutine):
     """Run a coroutine in the current event loop or create a new one if there isn't one."""
+    # First, clean up any existing Rich live displays
+    # This prevents "Only one live display may be active at once" errors
+    # especially after keyboard interrupts in environments like Colab
+    try:
+        # Get all live displays from all console instances
+        from rich import get_console
+
+        console = get_console()
+        if hasattr(console, "_live") and console._live is not None:
+            try:
+                console._live.stop()
+                console._live = None
+            except Exception:
+                # If stopping fails, just set to None
+                console._live = None
+    except Exception:
+        # If any error occurs during cleanup, just continue
+        pass
+
     try:
         # This call will raise an RuntimError if there is no event loop running.
         asyncio.get_running_loop()

--- a/src/bespokelabs/curator/request_processor/event_loop.py
+++ b/src/bespokelabs/curator/request_processor/event_loop.py
@@ -1,8 +1,6 @@
 import asyncio
 
 import nest_asyncio
-from rich.console import Console
-from rich.live import Live
 
 
 def run_in_event_loop(coroutine):

--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -69,6 +69,15 @@ class BatchStatusTracker(BaseModel):
         """Start the progress tracker with rich console output."""
         self._console = _CONSOLE if console is None else console
 
+        # Safety check: ensure any existing live display is stopped
+        if hasattr(self._console, "_live") and self._console._live is not None:
+            try:
+                self._console._live.stop()
+                self._console._live = None
+            except Exception:
+                # If stopping fails, just set to None
+                self._console._live = None
+
         # Create progress bar display
         self._progress = Progress(
             BarColumn(bar_width=None),

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -10,13 +10,7 @@ from rich import box
 from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TextColumn,
-    TimeElapsedColumn,
-    TimeRemainingColumn,
-)
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.table import Table
 
 from bespokelabs.curator import _CONSOLE
@@ -103,9 +97,7 @@ class OnlineStatusTracker:
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             self.available_token_capacity = t.cast(float, self.available_token_capacity)
         else:
-            self.available_token_capacity = t.cast(
-                _TokenUsage, self.available_token_capacity
-            )
+            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
             self.available_token_capacity = _TokenUsage()
             if not self.max_tokens_per_minute:
                 self.max_tokens_per_minute = _TokenUsage()
@@ -157,39 +149,17 @@ class OnlineStatusTracker:
         )
 
         if self.model in model_cost:
-            self.input_cost_per_million = (
-                model_cost[self.model]["input_cost_per_token"] * 1_000_000
-            )
-            self.output_cost_per_million = (
-                model_cost[self.model]["output_cost_per_token"] * 1_000_000
-            )
+            self.input_cost_per_million = model_cost[self.model]["input_cost_per_token"] * 1_000_000
+            self.output_cost_per_million = model_cost[self.model]["output_cost_per_token"] * 1_000_000
         else:
             from bespokelabs.curator.cost import external_model_cost
 
-            self.input_cost_per_million = (
-                external_model_cost(self.model, provider=self.compatible_provider)[
-                    "input_cost_per_token"
-                ]
-                * 1_000_000
-            )
-            self.output_cost_per_million = (
-                external_model_cost(self.model, provider=self.compatible_provider)[
-                    "output_cost_per_token"
-                ]
-                * 1_000_000
-            )
+            self.input_cost_per_million = external_model_cost(self.model, provider=self.compatible_provider)["input_cost_per_token"] * 1_000_000
+            self.output_cost_per_million = external_model_cost(self.model, provider=self.compatible_provider)["output_cost_per_token"] * 1_000_000
 
         # Handle None values for cost per million tokens
-        self.input_cost_str = (
-            f"[red]${self.input_cost_per_million:.3f}[/red]"
-            if self.input_cost_per_million is not None
-            else "[dim]N/A[/dim]"
-        )
-        self.output_cost_str = (
-            f"[red]${self.output_cost_per_million:.3f}[/red]"
-            if self.output_cost_per_million is not None
-            else "[dim]N/A[/dim]"
-        )
+        self.input_cost_str = f"[red]${self.input_cost_per_million:.3f}[/red]" if self.input_cost_per_million is not None else "[dim]N/A[/dim]"
+        self.output_cost_str = f"[red]${self.output_cost_per_million:.3f}[/red]" if self.output_cost_per_million is not None else "[dim]N/A[/dim]"
 
         # Create Live display with both progress and stats in one panel
         self._live = Live(
@@ -221,9 +191,7 @@ class OnlineStatusTracker:
         projected_total = self.total_cost + self.projected_remaining_cost
 
         # Update max concurrent requests seen
-        self.max_concurrent_requests_seen = max(
-            self.max_concurrent_requests_seen, self.num_tasks_in_progress
-        )
+        self.max_concurrent_requests_seen = max(self.max_concurrent_requests_seen, self.num_tasks_in_progress)
 
         # Format stats text
         stats_text = (
@@ -271,11 +239,7 @@ class OnlineStatusTracker:
         )
 
         # Add curator viewer link if client is available and hosted
-        if (
-            self.viewer_client
-            and self.viewer_client.hosted
-            and self.viewer_client.curator_viewer_url
-        ):
+        if self.viewer_client and self.viewer_client.hosted and self.viewer_client.curator_viewer_url:
             viewer_text = (
                 f"[bold white]Curator Viewer:[/bold white] "
                 f"[blue][link={self.viewer_client.curator_viewer_url}]:sparkles: Open Curator Viewer[/link] :sparkles:[/blue]\n"
@@ -334,16 +298,12 @@ class OnlineStatusTracker:
         # Model Information
         table.add_row("Model", "", style="bold magenta")
         table.add_row("Name", f"[blue]{self.model}[/blue]")
-        table.add_row(
-            "Rate Limit (RPM)", f"[blue]{self.max_requests_per_minute}[/blue]"
-        )
+        table.add_row("Rate Limit (RPM)", f"[blue]{self.max_requests_per_minute}[/blue]")
         table.add_row("Rate Limit (TPM)", f"[blue]{self.max_tokens_per_minute}[/blue]")
 
         # Request Statistics
         table.add_row("Requests", "", style="bold magenta")
-        table.add_row(
-            "Total Processed", str(self.num_tasks_succeeded + self.num_tasks_failed)
-        )
+        table.add_row("Total Processed", str(self.num_tasks_succeeded + self.num_tasks_failed))
         table.add_row("Successful", f"[green]{self.num_tasks_succeeded}[/green]")
         table.add_row("Failed", f"[red]{self.num_tasks_failed}[/red]")
 
@@ -427,37 +387,29 @@ class OnlineStatusTracker:
         seconds_since_update = current_time - self.last_update_time
         if self.max_requests_per_minute is not None:
             self.available_request_capacity = min(
-                self.available_request_capacity
-                + self.max_requests_per_minute * seconds_since_update / 60.0,
+                self.available_request_capacity + self.max_requests_per_minute * seconds_since_update / 60.0,
                 self.max_requests_per_minute,
             )
 
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             if self.max_tokens_per_minute is not None:
-                self.available_token_capacity = t.cast(
-                    int, self.available_token_capacity
-                )
+                self.available_token_capacity = t.cast(int, self.available_token_capacity)
                 self.max_tokens_per_minute = t.cast(int, self.max_tokens_per_minute)
                 self.available_token_capacity = min(
-                    self.available_token_capacity
-                    + self.max_tokens_per_minute * seconds_since_update / 60.0,
+                    self.available_token_capacity + self.max_tokens_per_minute * seconds_since_update / 60.0,
                     self.max_tokens_per_minute,
                 )
         else:
-            self.available_token_capacity = t.cast(
-                _TokenUsage, self.available_token_capacity
-            )
+            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
             self.max_tokens_per_minute = t.cast(_TokenUsage, self.max_tokens_per_minute)
             if self.max_tokens_per_minute.input is not None:
                 self.available_token_capacity.input = min(
-                    self.available_token_capacity.input
-                    + self.max_tokens_per_minute.input * seconds_since_update / 60.0,
+                    self.available_token_capacity.input + self.max_tokens_per_minute.input * seconds_since_update / 60.0,
                     self.max_tokens_per_minute.input,
                 )
             if self.max_tokens_per_minute.output is not None:
                 self.available_token_capacity.output = min(
-                    self.available_token_capacity.output
-                    + self.max_tokens_per_minute.output * seconds_since_update / 60.0,
+                    self.available_token_capacity.output + self.max_tokens_per_minute.output * seconds_since_update / 60.0,
                     self.max_tokens_per_minute.output,
                 )
 
@@ -485,20 +437,12 @@ class OnlineStatusTracker:
             return True
 
         token_estimate = token_estimate.total
-        has_capacity = (
-            self.available_request_capacity >= 1
-            and self.available_token_capacity >= token_estimate
-        )
+        has_capacity = self.available_request_capacity >= 1 and self.available_token_capacity >= token_estimate
         return has_capacity
 
     def _check_seperate_capacity(self, token_estimate: _TokenUsage):
-        self.available_token_capacity = t.cast(
-            _TokenUsage, self.available_token_capacity
-        )
-        if (
-            self.max_tokens_per_minute.total is None
-            and self.max_requests_per_minute is None
-        ):
+        self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
+        if self.max_tokens_per_minute.total is None and self.max_requests_per_minute is None:
             return True
 
         has_capacity = (
@@ -514,14 +458,10 @@ class OnlineStatusTracker:
             self.available_request_capacity -= 1
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             if self.max_tokens_per_minute is not None:
-                self.available_token_capacity = t.cast(
-                    float, self.available_token_capacity
-                )
+                self.available_token_capacity = t.cast(float, self.available_token_capacity)
                 self.available_token_capacity -= token_estimate.total
         else:
-            self.available_token_capacity = t.cast(
-                _TokenUsage, self.available_token_capacity
-            )
+            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
 
             if self.max_tokens_per_minute is not None:
                 self.available_token_capacity.input -= token_estimate.input
@@ -553,36 +493,26 @@ class OnlineStatusTracker:
         output_cost = (output_tokens * (self.output_cost_per_million or 0)) / 1_000_000
         return input_cost + output_cost
 
-    def update_cost_projection(
-        self, token_count: _TokenUsage | None, pre_request: bool = False
-    ):
+    def update_cost_projection(self, token_count: _TokenUsage | None, pre_request: bool = False):
         """Update cost projections based on token estimates or actual usage."""
         # Calculate estimated cost
         if token_count is None:
             estimated_cost = 0
         else:
-            estimated_cost = self.estimate_request_cost(
-                token_count.input, token_count.output
-            )
+            estimated_cost = self.estimate_request_cost(token_count.input, token_count.output)
 
         if pre_request:
             # This is a new estimate before API call
             # Update moving average of estimates
             self.num_estimates += 1
-            self.estimated_cost_average = (
-                self.estimated_cost_average * (self.num_estimates - 1) + estimated_cost
-            ) / self.num_estimates
+            self.estimated_cost_average = (self.estimated_cost_average * (self.num_estimates - 1) + estimated_cost) / self.num_estimates
         else:
             # Decrement estimate count since we're getting actual results (success or failure)
             if self.num_estimates > 0:
                 self.num_estimates -= 1
 
         # Calculate remaining cost using current estimates and remaining requests
-        remaining_requests = self.total_requests - (
-            self.num_tasks_succeeded
-            + self.num_tasks_failed
-            + self.num_tasks_already_completed
-        )
+        remaining_requests = self.total_requests - (self.num_tasks_succeeded + self.num_tasks_failed + self.num_tasks_already_completed)
         if self.num_estimates > 0:
             in_flight_cost = self.estimated_cost_average * self.num_estimates
 
@@ -590,24 +520,14 @@ class OnlineStatusTracker:
                 # Calculate weighted average between actual and in-flight costs
                 avg_actual_cost = self.total_cost / self.num_tasks_succeeded
 
-                total_weight = (
-                    self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR
-                ) + self.num_estimates
-                weighted_avg_cost = (
-                    (
-                        avg_actual_cost
-                        * (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR)
-                    )
-                    + in_flight_cost
-                ) / total_weight
+                total_weight = (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR) + self.num_estimates
+                weighted_avg_cost = ((avg_actual_cost * (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR)) + in_flight_cost) / total_weight
 
                 # Calculate remaining cost using weighted average
                 self.projected_remaining_cost = weighted_avg_cost * remaining_requests
             else:
                 # If no successful requests, use average of in-flight estimates
-                self.projected_remaining_cost = (
-                    self.estimated_cost_average * remaining_requests
-                )
+                self.projected_remaining_cost = self.estimated_cost_average * remaining_requests
 
         else:
             # No in-flight requests, use actual average if available

--- a/src/bespokelabs/curator/status_tracker/online_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/online_status_tracker.py
@@ -10,7 +10,13 @@ from rich import box
 from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
-from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 from rich.table import Table
 
 from bespokelabs.curator import _CONSOLE
@@ -97,7 +103,9 @@ class OnlineStatusTracker:
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             self.available_token_capacity = t.cast(float, self.available_token_capacity)
         else:
-            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
+            self.available_token_capacity = t.cast(
+                _TokenUsage, self.available_token_capacity
+            )
             self.available_token_capacity = _TokenUsage()
             if not self.max_tokens_per_minute:
                 self.max_tokens_per_minute = _TokenUsage()
@@ -105,6 +113,15 @@ class OnlineStatusTracker:
     def start_tracker(self, console: Optional[Console] = None):
         """Start the tracker."""
         self._console = _CONSOLE if console is None else console
+
+        # Safety check: ensure any existing live display is stopped
+        if hasattr(self._console, "_live") and self._console._live is not None:
+            try:
+                self._console._live.stop()
+                self._console._live = None
+            except Exception:
+                # If stopping fails, just set to None
+                self._console._live = None
 
         # Create progress bar display
         self._progress = Progress(
@@ -140,17 +157,39 @@ class OnlineStatusTracker:
         )
 
         if self.model in model_cost:
-            self.input_cost_per_million = model_cost[self.model]["input_cost_per_token"] * 1_000_000
-            self.output_cost_per_million = model_cost[self.model]["output_cost_per_token"] * 1_000_000
+            self.input_cost_per_million = (
+                model_cost[self.model]["input_cost_per_token"] * 1_000_000
+            )
+            self.output_cost_per_million = (
+                model_cost[self.model]["output_cost_per_token"] * 1_000_000
+            )
         else:
             from bespokelabs.curator.cost import external_model_cost
 
-            self.input_cost_per_million = external_model_cost(self.model, provider=self.compatible_provider)["input_cost_per_token"] * 1_000_000
-            self.output_cost_per_million = external_model_cost(self.model, provider=self.compatible_provider)["output_cost_per_token"] * 1_000_000
+            self.input_cost_per_million = (
+                external_model_cost(self.model, provider=self.compatible_provider)[
+                    "input_cost_per_token"
+                ]
+                * 1_000_000
+            )
+            self.output_cost_per_million = (
+                external_model_cost(self.model, provider=self.compatible_provider)[
+                    "output_cost_per_token"
+                ]
+                * 1_000_000
+            )
 
         # Handle None values for cost per million tokens
-        self.input_cost_str = f"[red]${self.input_cost_per_million:.3f}[/red]" if self.input_cost_per_million is not None else "[dim]N/A[/dim]"
-        self.output_cost_str = f"[red]${self.output_cost_per_million:.3f}[/red]" if self.output_cost_per_million is not None else "[dim]N/A[/dim]"
+        self.input_cost_str = (
+            f"[red]${self.input_cost_per_million:.3f}[/red]"
+            if self.input_cost_per_million is not None
+            else "[dim]N/A[/dim]"
+        )
+        self.output_cost_str = (
+            f"[red]${self.output_cost_per_million:.3f}[/red]"
+            if self.output_cost_per_million is not None
+            else "[dim]N/A[/dim]"
+        )
 
         # Create Live display with both progress and stats in one panel
         self._live = Live(
@@ -182,7 +221,9 @@ class OnlineStatusTracker:
         projected_total = self.total_cost + self.projected_remaining_cost
 
         # Update max concurrent requests seen
-        self.max_concurrent_requests_seen = max(self.max_concurrent_requests_seen, self.num_tasks_in_progress)
+        self.max_concurrent_requests_seen = max(
+            self.max_concurrent_requests_seen, self.num_tasks_in_progress
+        )
 
         # Format stats text
         stats_text = (
@@ -230,7 +271,11 @@ class OnlineStatusTracker:
         )
 
         # Add curator viewer link if client is available and hosted
-        if self.viewer_client and self.viewer_client.hosted and self.viewer_client.curator_viewer_url:
+        if (
+            self.viewer_client
+            and self.viewer_client.hosted
+            and self.viewer_client.curator_viewer_url
+        ):
             viewer_text = (
                 f"[bold white]Curator Viewer:[/bold white] "
                 f"[blue][link={self.viewer_client.curator_viewer_url}]:sparkles: Open Curator Viewer[/link] :sparkles:[/blue]\n"
@@ -289,12 +334,16 @@ class OnlineStatusTracker:
         # Model Information
         table.add_row("Model", "", style="bold magenta")
         table.add_row("Name", f"[blue]{self.model}[/blue]")
-        table.add_row("Rate Limit (RPM)", f"[blue]{self.max_requests_per_minute}[/blue]")
+        table.add_row(
+            "Rate Limit (RPM)", f"[blue]{self.max_requests_per_minute}[/blue]"
+        )
         table.add_row("Rate Limit (TPM)", f"[blue]{self.max_tokens_per_minute}[/blue]")
 
         # Request Statistics
         table.add_row("Requests", "", style="bold magenta")
-        table.add_row("Total Processed", str(self.num_tasks_succeeded + self.num_tasks_failed))
+        table.add_row(
+            "Total Processed", str(self.num_tasks_succeeded + self.num_tasks_failed)
+        )
         table.add_row("Successful", f"[green]{self.num_tasks_succeeded}[/green]")
         table.add_row("Failed", f"[red]{self.num_tasks_failed}[/red]")
 
@@ -304,13 +353,25 @@ class OnlineStatusTracker:
         table.add_row("Total Input Tokens", f"{self.total_prompt_tokens:,}")
         table.add_row("Total Output Tokens", f"{self.total_completion_tokens:,}")
         if self.num_tasks_succeeded > 0:
-            table.add_row("Average Tokens per Request", f"{int(self.total_tokens / self.num_tasks_succeeded)}")
-            table.add_row("Average Input Tokens", f"{int(self.total_prompt_tokens / self.num_tasks_succeeded)}")
-            table.add_row("Average Output Tokens", f"{int(self.total_completion_tokens / self.num_tasks_succeeded)}")
+            table.add_row(
+                "Average Tokens per Request",
+                f"{int(self.total_tokens / self.num_tasks_succeeded)}",
+            )
+            table.add_row(
+                "Average Input Tokens",
+                f"{int(self.total_prompt_tokens / self.num_tasks_succeeded)}",
+            )
+            table.add_row(
+                "Average Output Tokens",
+                f"{int(self.total_completion_tokens / self.num_tasks_succeeded)}",
+            )
         # Cost Statistics
         table.add_row("Costs", "", style="bold magenta")
         table.add_row("Total Cost", f"[red]${self.total_cost:.3f}[/red]")
-        table.add_row("Average Cost per Request", f"[red]${self.total_cost / max(1, self.num_tasks_succeeded):.3f}[/red]")
+        table.add_row(
+            "Average Cost per Request",
+            f"[red]${self.total_cost / max(1, self.num_tasks_succeeded):.3f}[/red]",
+        )
 
         table.add_row("Input Cost per 1M Tokens", self.input_cost_str)
         table.add_row("Output Cost per 1M Tokens", self.output_cost_str)
@@ -324,7 +385,10 @@ class OnlineStatusTracker:
         output_tpm = self.total_completion_tokens / max(0.001, elapsed_minutes)
 
         table.add_row("Total Time", f"{elapsed_time:.2f}s")
-        table.add_row("Average Time per Request", f"{elapsed_time / max(1, self.num_tasks_succeeded):.2f}s")
+        table.add_row(
+            "Average Time per Request",
+            f"{elapsed_time / max(1, self.num_tasks_succeeded):.2f}s",
+        )
         table.add_row("Requests per Minute", f"{rpm:.1f}")
         table.add_row("Max Concurrent Requests", str(self.max_concurrent_requests_seen))
         table.add_row("Input Tokens per Minute", f"{input_tpm:.1f}")
@@ -363,29 +427,38 @@ class OnlineStatusTracker:
         seconds_since_update = current_time - self.last_update_time
         if self.max_requests_per_minute is not None:
             self.available_request_capacity = min(
-                self.available_request_capacity + self.max_requests_per_minute * seconds_since_update / 60.0,
+                self.available_request_capacity
+                + self.max_requests_per_minute * seconds_since_update / 60.0,
                 self.max_requests_per_minute,
             )
 
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             if self.max_tokens_per_minute is not None:
-                self.available_token_capacity = t.cast(int, self.available_token_capacity)
+                self.available_token_capacity = t.cast(
+                    int, self.available_token_capacity
+                )
                 self.max_tokens_per_minute = t.cast(int, self.max_tokens_per_minute)
                 self.available_token_capacity = min(
-                    self.available_token_capacity + self.max_tokens_per_minute * seconds_since_update / 60.0,
+                    self.available_token_capacity
+                    + self.max_tokens_per_minute * seconds_since_update / 60.0,
                     self.max_tokens_per_minute,
                 )
         else:
-            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
+            self.available_token_capacity = t.cast(
+                _TokenUsage, self.available_token_capacity
+            )
             self.max_tokens_per_minute = t.cast(_TokenUsage, self.max_tokens_per_minute)
             if self.max_tokens_per_minute.input is not None:
                 self.available_token_capacity.input = min(
-                    self.available_token_capacity.input + self.max_tokens_per_minute.input * seconds_since_update / 60.0,
+                    self.available_token_capacity.input
+                    + self.max_tokens_per_minute.input * seconds_since_update / 60.0,
                     self.max_tokens_per_minute.input,
                 )
             if self.max_tokens_per_minute.output is not None:
                 self.available_token_capacity.output = min(
-                    self.available_token_capacity.output + self.max_tokens_per_minute.output * seconds_since_update / 60.0, self.max_tokens_per_minute.output
+                    self.available_token_capacity.output
+                    + self.max_tokens_per_minute.output * seconds_since_update / 60.0,
+                    self.max_tokens_per_minute.output,
                 )
 
         self.last_update_time = current_time
@@ -412,12 +485,20 @@ class OnlineStatusTracker:
             return True
 
         token_estimate = token_estimate.total
-        has_capacity = self.available_request_capacity >= 1 and self.available_token_capacity >= token_estimate
+        has_capacity = (
+            self.available_request_capacity >= 1
+            and self.available_token_capacity >= token_estimate
+        )
         return has_capacity
 
     def _check_seperate_capacity(self, token_estimate: _TokenUsage):
-        self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
-        if self.max_tokens_per_minute.total is None and self.max_requests_per_minute is None:
+        self.available_token_capacity = t.cast(
+            _TokenUsage, self.available_token_capacity
+        )
+        if (
+            self.max_tokens_per_minute.total is None
+            and self.max_requests_per_minute is None
+        ):
             return True
 
         has_capacity = (
@@ -433,10 +514,14 @@ class OnlineStatusTracker:
             self.available_request_capacity -= 1
         if self.token_limit_strategy == TokenLimitStrategy.combined:
             if self.max_tokens_per_minute is not None:
-                self.available_token_capacity = t.cast(float, self.available_token_capacity)
+                self.available_token_capacity = t.cast(
+                    float, self.available_token_capacity
+                )
                 self.available_token_capacity -= token_estimate.total
         else:
-            self.available_token_capacity = t.cast(_TokenUsage, self.available_token_capacity)
+            self.available_token_capacity = t.cast(
+                _TokenUsage, self.available_token_capacity
+            )
 
             if self.max_tokens_per_minute is not None:
                 self.available_token_capacity.input -= token_estimate.input
@@ -468,26 +553,36 @@ class OnlineStatusTracker:
         output_cost = (output_tokens * (self.output_cost_per_million or 0)) / 1_000_000
         return input_cost + output_cost
 
-    def update_cost_projection(self, token_count: _TokenUsage | None, pre_request: bool = False):
+    def update_cost_projection(
+        self, token_count: _TokenUsage | None, pre_request: bool = False
+    ):
         """Update cost projections based on token estimates or actual usage."""
         # Calculate estimated cost
         if token_count is None:
             estimated_cost = 0
         else:
-            estimated_cost = self.estimate_request_cost(token_count.input, token_count.output)
+            estimated_cost = self.estimate_request_cost(
+                token_count.input, token_count.output
+            )
 
         if pre_request:
             # This is a new estimate before API call
             # Update moving average of estimates
             self.num_estimates += 1
-            self.estimated_cost_average = (self.estimated_cost_average * (self.num_estimates - 1) + estimated_cost) / self.num_estimates
+            self.estimated_cost_average = (
+                self.estimated_cost_average * (self.num_estimates - 1) + estimated_cost
+            ) / self.num_estimates
         else:
             # Decrement estimate count since we're getting actual results (success or failure)
             if self.num_estimates > 0:
                 self.num_estimates -= 1
 
         # Calculate remaining cost using current estimates and remaining requests
-        remaining_requests = self.total_requests - (self.num_tasks_succeeded + self.num_tasks_failed + self.num_tasks_already_completed)
+        remaining_requests = self.total_requests - (
+            self.num_tasks_succeeded
+            + self.num_tasks_failed
+            + self.num_tasks_already_completed
+        )
         if self.num_estimates > 0:
             in_flight_cost = self.estimated_cost_average * self.num_estimates
 
@@ -495,14 +590,24 @@ class OnlineStatusTracker:
                 # Calculate weighted average between actual and in-flight costs
                 avg_actual_cost = self.total_cost / self.num_tasks_succeeded
 
-                total_weight = (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR) + self.num_estimates
-                weighted_avg_cost = ((avg_actual_cost * (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR)) + in_flight_cost) / total_weight
+                total_weight = (
+                    self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR
+                ) + self.num_estimates
+                weighted_avg_cost = (
+                    (
+                        avg_actual_cost
+                        * (self.num_tasks_succeeded * _SUCCESS_WEIGHT_FACTOR)
+                    )
+                    + in_flight_cost
+                ) / total_weight
 
                 # Calculate remaining cost using weighted average
                 self.projected_remaining_cost = weighted_avg_cost * remaining_requests
             else:
                 # If no successful requests, use average of in-flight estimates
-                self.projected_remaining_cost = self.estimated_cost_average * remaining_requests
+                self.projected_remaining_cost = (
+                    self.estimated_cost_average * remaining_requests
+                )
 
         else:
             # No in-flight requests, use actual average if available


### PR DESCRIPTION
Previously in colab, when there's keyboard interrupt, the second time running curator, would get this error message
![image](https://github.com/user-attachments/assets/43fa08fe-7c57-451b-b7d4-36bd9a0a3e1c)

The error LiveError: Only one live display may be active at once occurs because trying to create a second Rich Live display while one is already active. This typically happens when a previous run wasn't properly terminated, which is common after keyboard interruption.

Fixing this behavior. 

Also in this PR, lint for online status tracker. 