### PR TITLE
remove split from card template

### DIFF
--- a/src/bespokelabs/curator/hf_card_template.py
+++ b/src/bespokelabs/curator/hf_card_template.py
@@ -29,7 +29,7 @@ You can load this dataset using the following code:
 ```python
 from datasets import load_dataset
 
-dataset = load_dataset("{repo_id}", split="default")
+dataset = load_dataset("{repo_id}")
 ```
 
 """


### PR DESCRIPTION
Split will normally be "train," but I think it's fine to leave it out. 