### PR TITLE
Fix/deepseek/rpm

### DIFF
--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -368,7 +368,7 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
                     if status_tracker.max_tokens_per_minute is not None:
                         token_estimate = self.estimate_total_tokens(request.generic_request.messages)
                     else:
-                        token_estimate = None
+                        token_estimate = _TokenUsage()  # Empty
 
                     # Wait for capacity if needed
                     while not status_tracker.has_capacity(token_estimate):
@@ -409,7 +409,7 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
                     if status_tracker.max_tokens_per_minute is not None:
                         token_estimate = self.estimate_total_tokens(retry_request.generic_request.messages)
                     else:
-                        token_estimate = None
+                        token_estimate = _TokenUsage()  # Empty
 
                     attempt_number = self.config.max_retries - retry_request.attempts_left
                     logger.debug(

--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -352,6 +352,8 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
                     generic_request = GenericRequest.model_validate_json(line)
 
                     if generic_request.original_row_idx in completed_request_ids:
+                        if self._semaphore:
+                            self._semaphore.release()
                         continue
 
                     # Unpack multimodal prompts

--- a/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
@@ -107,7 +107,8 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             self.api_key = self.config.api_key or os.getenv("DEEPSEEK_API_KEY")
             self._longlived_response = True
             self.config.request_timeout = 60 * 30  # 30 minutes
-            self.manual_max_concurrent_requests = 10_000
+            self.manual_max_concurrent_requests = config.max_concurrent_requests or 10_000
+            self.default_max_tokens_per_minute = None
         else:
             self.api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             self.header_based_max_requests_per_minute, self.header_based_max_tokens_per_minute = self.get_header_based_rate_limits()


### PR DESCRIPTION
- There is a nasty bug in concurrent strategy where we were not releasing semaphore for success strategy
- max_tpm should be `None` for deepseek by default. 