### PR TITLE
Fix/curator-cli-batch-update-freq-increase

### DIFF
--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -237,8 +237,9 @@ class BatchStatusTracker(BaseModel):
             # Update TQDM description with key metrics
             self.pbar.set_description(
                 f"Processing {MODEL}{self.model}{END} "
-                f"[{WARNING}{self.n_submitted_batches} batches running{END} • "
-                f"{COST}${self.total_cost:.3f} spent{END}]"
+                f"[Batches: {SUCCESS}{self.n_downloaded_batches}✓{END}/{WARNING}{self.n_submitted_batches}⋯{END} • "
+                f"Reqs: {SUCCESS}{self.n_succeeded_requests}✓{END}/{WARNING}{self.n_in_progress_requests}⋯{END}/{ERROR}{self.n_failed_requests}✗{END} • "
+                f"{COST}${self.total_cost:.3f}{END}]"
             )
 
             # Add curator viewer link if available
@@ -310,6 +311,10 @@ class BatchStatusTracker(BaseModel):
                         or self.n_downloaded_failed_requests != getattr(self, "_last_failed_requests", -1)
                         or self.total_tokens != getattr(self, "_last_total_tokens", -1)  # Token/cost changes
                         or self.total_cost != getattr(self, "_last_total_cost", -1)
+                        or self.n_finished_requests != getattr(self, "_last_n_finished_requests", -1)
+                        or self.n_in_progress_requests != getattr(self, "_last_n_in_progress_requests", -1)
+                        or self.n_succeeded_requests != getattr(self, "_last_n_succeeded_requests", -1)
+                        or self.n_failed_requests != getattr(self, "_last_n_failed_requests", -1)
                     )
                 )
 
@@ -324,6 +329,10 @@ class BatchStatusTracker(BaseModel):
                     self._last_failed_requests = self.n_downloaded_failed_requests
                     self._last_total_tokens = self.total_tokens
                     self._last_total_cost = self.total_cost
+                    self._last_n_finished_requests = self.n_finished_requests
+                    self._last_n_in_progress_requests = self.n_in_progress_requests
+                    self._last_n_succeeded_requests = self.n_succeeded_requests
+                    self._last_n_failed_requests = self.n_failed_requests
 
     def stop_tracker(self):
         """Stop the tracker and display final statistics."""

--- a/tests/integrations/test_all.py
+++ b/tests/integrations/test_all.py
@@ -451,7 +451,7 @@ def test_basic_batch(temp_working_dir, mock_dataset):
         # Verify status tracker output
         captured = output.getvalue()
         assert "Batches: Total: 1 • Submitted: 0⋯ • Downloaded: 1✓" in captured, captured
-        assert "Requests: Total: 3 • Submitted: 0⋯ • Succeeded: 3✓ • Failed: 0✗" in captured, captured
+        assert "Requests: Total: 3 • In Progress: 0⋯ • Succeeded: 3✓ • Failed: 0✗" in captured, captured
         assert "Final Curator Statistics" in captured, captured
         assert "Total Requests             │ 3" in captured, captured
         assert "Successful                 │ 3" in captured, captured
@@ -492,7 +492,7 @@ def test_batch_resubmission(caplog, temp_working_dir, mock_dataset):
         assert "Invalid finish responses: {'length': 1}" in caplog.text
 
         assert "Batches: Total: 3 • Submitted: 0⋯ • Downloaded: 3✓" in captured, captured
-        assert "Requests: Total: 3 • Submitted: 0⋯ • Succeeded: 4✓ • Failed: 1✗" in captured, captured
+        assert "Requests: Total: 3 • In Progress: 0⋯ • Succeeded: 4✓ • Failed: 1✗" in captured, captured
         assert "Final Curator Statistics" in captured, captured
         assert "Total Requests             │ 3" in captured, captured
         assert "Successful                 │ 4" in captured, captured


### PR DESCRIPTION
Previously, curator CLI batch update statistics whenever a whole batch is updated. However, the intermediate progress for large batches are not reflected in request level. 

Now, use both **submitted** and downloaded batch to calculate request statistics (submitted, success, fail).

<img width="1395" alt="image" src="https://github.com/user-attachments/assets/4fe0773a-9197-4e61-bf4a-67bba88d2dac" />

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/bb40eec3-d50b-4e42-91a3-b7da817178c1" />
