### PR TITLE
Add gpt-4.1 structured output support

### DIFF
--- a/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
@@ -229,6 +229,9 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             - gpt-4o with date >= 2024-08-06 or latest
             - o1 with date >= 2024-12-17 or latest
             - o3-mini with date >= 2025-01-31 or latest
+            - gpt-4.1 latest
+            - gpt-4.1-mini latest
+            - gpt-4.1-nano latest
         """
         model_name = self.config.model.lower()
 
@@ -240,8 +243,8 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             if mini_date >= datetime(2024, 7, 18):
                 return True
 
-        # Check gpt-4o, o1, o3-mini support.
-        if model_name in ["gpt-4o", "o1"]:  # Latest version
+        # Check gpt-4o, o1, o3-mini, gpt-4.1 support.
+        if model_name in ["gpt-4o", "o1", "gpt-4.1"]:  # Latest version
             return True
         if "gpt-4o-" in model_name:
             base_date = datetime.datetime.strptime(model_name.split("gpt-4o-")[1], "%Y-%m-%d")

--- a/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/openai_online_request_processor.py
@@ -244,7 +244,7 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
                 return True
 
         # Check gpt-4o, o1, o3-mini, gpt-4.1 support.
-        if model_name in ["gpt-4o", "o1", "gpt-4.1"]:  # Latest version
+        if model_name in ["gpt-4o", "o1"]:  # Latest version
             return True
         if "gpt-4o-" in model_name:
             base_date = datetime.datetime.strptime(model_name.split("gpt-4o-")[1], "%Y-%m-%d")
@@ -259,7 +259,7 @@ class OpenAIOnlineRequestProcessor(BaseOnlineRequestProcessor, OpenAIRequestMixi
             if base_date >= datetime.datetime(2025, 1, 31):  # Support o3-mini dated versions from 2025-01-31
                 return True
         # Source: https://platform.openai.com/docs/models/gpt-4.1, https://platform.openai.com/docs/models/gpt-4.1-mini, https://platform.openai.com/docs/models/gpt-4.1-nano
-        if "gpt-4.1-" in model_name:
+        if "gpt-4.1" in model_name:
             return True
         return False
 


### PR DESCRIPTION
The previous [fix](https://github.com/bespokelabsai/curator/pull/637) for issue #635 added checks for the gpt-4.1-mini and gpt-4.1-nano models but inadvertently omitted support for the gpt-4.1 model. This PR addresses that by adding support for gpt-4.1 as well.