### PR TITLE
feat: add response object in curator

### DIFF
--- a/examples/litellm-recipe-generation/litellm_recipe_prompting.py
+++ b/examples/litellm-recipe-generation/litellm_recipe_prompting.py
@@ -53,16 +53,15 @@ def main():
     #############################################
 
     recipe_generator = RecipeGenerator(
-        model_name="gemini/gemini-1.5-flash",
-        backend="litellm",  # Optional
-        backend_params={"max_requests_per_minute": 2_000, "max_tokens_per_minute": 4_000_000},
+        model_name="gpt-4o-mini",
     )
 
     # Generate recipes for all cuisines
     recipes = recipe_generator(cuisines)
 
     # Print results
-    print(recipes.to_pandas())
+    breakpoint()
+    print(recipes.dataset.to_pandas())
 
 
 if __name__ == "__main__":

--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -54,6 +54,7 @@ class BaseRequestProcessor(ABC):
         self._viewer_client = None
         self.config = config
         self._cost_processor = cost_processor_factory(config=self.config, backend=self.backend)
+        self._is_cached_dataset = False
 
     @property
     @abstractmethod
@@ -127,6 +128,7 @@ class BaseRequestProcessor(ABC):
         # load from already completed dataset
         output_dataset = self.attempt_loading_cached_dataset(parse_func_hash)
         if output_dataset is not None:
+            self._is_cached_dataset = True
             return output_dataset
         logger.info(f"Running {self.__class__.__name__} completions with model: {self.config.model}")
 
@@ -311,6 +313,7 @@ class BaseRequestProcessor(ABC):
             await f.write(json.dumps(metadata_dict, indent=4) + "\n")
 
         logger.info(f"Wrote {num_requests} requests to {request_file}.")
+    
 
     def attempt_loading_cached_dataset(self, parse_func_hash: str) -> Optional["Dataset"]:
         """Attempt to load a cached dataset file.

--- a/src/bespokelabs/curator/types/curator_response.py
+++ b/src/bespokelabs/curator/types/curator_response.py
@@ -1,0 +1,153 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Union
+from pathlib import Path
+import json
+import os
+
+from datasets import Dataset
+
+
+@dataclass
+class TokenUsage:
+    """Token usage statistics."""
+    input: int = 0
+    output: int = 0
+    total: int = 0
+
+
+@dataclass
+class CostInfo:
+    """Cost information."""
+    total_cost: float = 0.0
+    input_cost_per_million: Optional[float] = None
+    output_cost_per_million: Optional[float] = None
+    projected_remaining_cost: float = 0.0
+
+
+@dataclass
+class RequestStats:
+    """Request statistics."""
+    total: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    in_progress: int = 0
+    cached: int = 0
+
+
+@dataclass
+class PerformanceStats:
+    """Performance statistics."""
+    total_time: float = 0.0
+    requests_per_minute: float = 0.0
+    input_tokens_per_minute: float = 0.0
+    output_tokens_per_minute: float = 0.0
+    max_concurrent_requests: int = 0
+
+
+@dataclass
+class CuratorResponse:
+    """Response from Curator LLM processing.
+    
+    This class encapsulates all the information about a Curator processing run,
+    including the dataset, failed requests, and various statistics.
+    """
+    # Core data
+    dataset: Dataset
+    failed_requests_path: Optional[Path] = None
+    
+    # Model information
+    model_name: str = ""
+    max_requests_per_minute: int = 0
+    max_tokens_per_minute: int = 0
+    
+    # Statistics
+    token_usage: TokenUsage = field(default_factory=TokenUsage)
+    cost_info: CostInfo = field(default_factory=CostInfo)
+    request_stats: RequestStats = field(default_factory=RequestStats)
+    performance_stats: PerformanceStats = field(default_factory=PerformanceStats)
+    
+    # Additional metadata
+    metadata: Dict[str, Any] = None
+    
+    def __post_init__(self):
+        if self.metadata is None:
+            self.metadata = {}
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the response to a dictionary."""
+        return {
+            "model_name": self.model_name,
+            "max_requests_per_minute": self.max_requests_per_minute,
+            "max_tokens_per_minute": self.max_tokens_per_minute,
+            "token_usage": {
+                "input": self.token_usage.input,
+                "output": self.token_usage.output,
+                "total": self.token_usage.total
+            },
+            "cost_info": {
+                "total_cost": self.cost_info.total_cost,
+                "input_cost_per_million": self.cost_info.input_cost_per_million,
+                "output_cost_per_million": self.cost_info.output_cost_per_million,
+                "projected_remaining_cost": self.cost_info.projected_remaining_cost
+            },
+            "request_stats": {
+                "total": self.request_stats.total,
+                "succeeded": self.request_stats.succeeded,
+                "failed": self.request_stats.failed,
+                "in_progress": self.request_stats.in_progress,
+                "cached": self.request_stats.cached
+            },
+            "performance_stats": {
+                "total_time": self.performance_stats.total_time,
+                "requests_per_minute": self.performance_stats.requests_per_minute,
+                "input_tokens_per_minute": self.performance_stats.input_tokens_per_minute,
+                "output_tokens_per_minute": self.performance_stats.output_tokens_per_minute,
+                "max_concurrent_requests": self.performance_stats.max_concurrent_requests
+            },
+            "metadata": self.metadata
+        }
+    
+    def save(self, cache_dir: Union[str, Path]) -> None:
+        """Save the response to a cache directory.
+        
+        Args:
+            cache_dir: Directory to save the response to
+        """
+        cache_dir = Path(cache_dir)
+        
+        # Save the response metadata
+        with open(os.path.join(cache_dir, "curator_response.json"), "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+    
+    @classmethod
+    def load(cls, cache_dir: Union[str, Path], dataset: Dataset) -> "CuratorResponse":
+        """Load a response from a cache directory.
+        
+        Args:
+            cache_dir: Directory containing the cached response
+            dataset: The dataset to use for the response
+            
+        Returns:
+            CuratorResponse: The loaded response
+        """
+        cache_dir = Path(cache_dir)
+        
+        # Load the response metadata
+        with open(os.path.join(cache_dir, "curator_response.json"), "r") as f:
+            data = json.load(f)
+        
+        # Create the response object
+        response = cls(
+            dataset=dataset,
+            failed_requests_path=os.path.join(cache_dir, "failed_requests.jsonl") if os.path.exists(os.path.join(cache_dir, "failed_requests.jsonl")) else None,
+            model_name=data["model_name"],
+            max_requests_per_minute=data["max_requests_per_minute"],
+            max_tokens_per_minute=data["max_tokens_per_minute"],
+            token_usage=TokenUsage(**data["token_usage"]),
+            cost_info=CostInfo(**data["cost_info"]),
+            request_stats=RequestStats(**data["request_stats"]),
+            performance_stats=PerformanceStats(**data["performance_stats"]),
+            metadata=data["metadata"]
+        )
+        
+        return response 


### PR DESCRIPTION
This pr added a feature which enables curator to return a `CuratorResponse` object, which encapsulates all the information about the run as a python object
like, token usage, requests stats, performance stats, failed_requests etc
