### PR TITLE
fix: migrate to `logger.warning`

### DIFF
--- a/src/bespokelabs/curator/code_executor/code_execution_backend/base_backend.py
+++ b/src/bespokelabs/curator/code_executor/code_execution_backend/base_backend.py
@@ -642,7 +642,7 @@ class BaseCodeExecutionBackend:
         seconds_since_rate_limit_error = time.time() - status_tracker.time_of_last_rate_limit_error
         remaining_seconds_to_pause = seconds_to_pause_on_rate_limit - seconds_since_rate_limit_error
         if remaining_seconds_to_pause > 0:
-            logger.warn(f"Pausing for {int(remaining_seconds_to_pause)} seconds")
+            logger.warning(f"Pausing for {int(remaining_seconds_to_pause)} seconds")
             await asyncio.sleep(remaining_seconds_to_pause)
 
     async def append_execution_response(self, data: dict, filename: str) -> None:

--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -302,7 +302,7 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
         seconds_since_rate_limit_error = time.time() - status_tracker.time_of_last_rate_limit_error
         remaining_seconds_to_pause = seconds_to_pause_on_rate_limit - seconds_since_rate_limit_error
         if remaining_seconds_to_pause > 0:
-            logger.warn(f"Pausing for {int(remaining_seconds_to_pause)} seconds")
+            logger.warning(f"Pausing for {int(remaining_seconds_to_pause)} seconds")
             await asyncio.sleep(remaining_seconds_to_pause)
             status_tracker.last_update_time = time.time()
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the `logger.warn` deprecation warnings:
```python
/home/runner/work/curator/curator/src/bespokelabs/curator/code_executor/code_execution_backend/base_backend.py:645: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```