### PR TITLE
fix: resolve Pydantic issues

### DIFF
--- a/src/bespokelabs/curator/request_processor/config.py
+++ b/src/bespokelabs/curator/request_processor/config.py
@@ -184,7 +184,7 @@ def _validate_backend_params(params: BackendParamsType):
     )
     for validator in validators:
         try:
-            validator.validate(params)
+            validator.model_validate(params)
         except ValidationError:
             continue
         else:

--- a/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
+++ b/src/bespokelabs/curator/status_tracker/batch_status_tracker.py
@@ -359,7 +359,7 @@ class BatchStatusTracker(BaseModel):
         telemetry_client.capture(
             TelemetryEvent(
                 event_type="BatchRequest",
-                metadata=json.loads(self.json()),
+                metadata=json.loads(self.model_dump_json()),
             )
         )
 


### PR DESCRIPTION
## PR Summary
This PR fixes two `PydanticDeprecatedSince20` warnings by:
- Replacing `validator.validate()` with `validator.model_validate()` in `request_processor/config.py`.
- Replacing `self.json()` with `self.model_dump_json()` in `status_tracker/batch_status_tracker.py`.
See [CI logs](https://github.com/bespokelabsai/curator/actions/runs/15496384844/job/43633987740#step:9:80) for those warnings.