### PR TITLE
Add FireworksTrainer for managed fine-tuning via Fireworks AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 </div>
 
 ## 🎉 What's New
+* **[2026.06.09]** [Fireworks AI integration for fine-tuning](examples/fireworks/): Run managed supervised fine-tuning (SFT) on Fireworks AI with `FireworksTrainer` — upload curated data, train a LoRA, and sample from the deployed model behind the same trainer interface as Tinker.
 * **[2026.03.14]** [Tinker integration for fine-tuning](examples/poem_finetuning_example.py): Go from curated data to a LoRA fine-tuned model in a few lines of Python using the Tinker SDK.
 * **[2025.12.05]** [Launched OpenThoughts-Agents](https://www.open-thoughts.ai/blog/agent) whose data was curated using Curator.
 * **[2025.04.09]** [Launching Reasoning Datasets Competition](https://huggingface.co/blog/bespokelabs/reasoning-datasets-competition) with HuggingFace and Together.ai. Win $5000 USD worth of prizes!
@@ -64,6 +65,7 @@ pip install bespokelabs-curator
 | **Sentiment analysis** | <a href="https://colab.research.google.com/drive/1Zfl3g7POsqqYQqkzXdyhYRSAymLhZugn?usp=sharing" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> | Aspect-based sentiment analysis of restaurant reviews and finetuning using Together.ai |
 | **RAFT for domain-specific RAG** | <a href="https://github.com/bespokelabsai/curator/tree/main/examples/blocks/raft" target="_blank">Code</a> | Implement Retrieval Augmented Fine-Tuning (RAFT) that processes domain-specific documents, generates questions, and prepares data for fine-tuning LLMs. |
 | **Poem generation & LoRA fine-tuning** | <a href="https://github.com/bespokelabsai/curator/blob/main/examples/poem_finetuning_example.py" target="_blank">Code</a> | End-to-end pipeline: curate poem data with Curator, then LoRA fine-tune with TinkerTrainer |
+| **Managed fine-tuning on Fireworks AI** | <a href="https://github.com/bespokelabsai/curator/tree/main/examples/fireworks" target="_blank">Code</a> | Run a managed SFT job on Fireworks AI with FireworksTrainer, then sample from the deployed LoRA model |
 
 ### Data Generation
 | **Task** | **Link(s)** | **Goal** |

--- a/README.md
+++ b/README.md
@@ -368,6 +368,56 @@ result = trainer.train([{"question": "What is 2+2?", "answer": "4"}, ...])
 
 See the full [poem fine-tuning example](examples/poem_finetuning_example.py) for an end-to-end pipeline that curates data with `curator.LLM` and then fine-tunes with `TinkerTrainer`.
 
+## 🎆 Fine-Tuning with Fireworks AI
+
+Curator also integrates with [Fireworks AI](https://docs.fireworks.ai/fine-tuning/fine-tuning-models) managed fine-tuning. Fireworks runs supervised fine-tuning (SFT) as a server-side job: your chat data is uploaded, an SFT job is submitted against a base model, and the resulting LoRA model is served for inference — all behind the same `BaseTrainer` interface as `TinkerTrainer`.
+
+```bash
+pip install bespokelabs-curator fireworks-ai   # fireworks-ai is an optional add-on
+export FIREWORKS_API_KEY="fw_..."
+```
+
+```python
+from bespokelabs.curator import FireworksTrainer, FireworksTrainerConfig
+
+# Configure the managed fine-tuning job
+config = FireworksTrainerConfig(
+    base_model="qwen3-4b",   # smallest fine-tunable Fireworks model
+    epochs=2,
+    lora_rank=8,             # power of two up to 32; None for full fine-tuning
+    learning_rate=1e-4,      # or omit to let Fireworks auto-select
+)
+
+# Training data is a list of chat-format dicts (or a HuggingFace Dataset).
+# Fireworks requires at least 3 examples.
+training_data = [
+    {"messages": [
+        {"role": "user", "content": "What is Python?"},
+        {"role": "assistant", "content": "Python is a programming language."},
+    ]},
+    # ...
+]
+
+# Upload data + run the supervised fine-tuning job (polls until complete)
+trainer = FireworksTrainer(config)
+result = trainer.train(training_data)
+print(f"Fine-tuned model: {result.weights_name}")
+
+# Sample from the fine-tuned model. Fine-tuned LoRA models can't be served
+# serverlessly, so this provisions an on-demand deployment (takes a few minutes).
+response = trainer.sample("Explain recursion in Python")
+print(response)
+
+trainer.close()   # tear down the deployment when done
+```
+
+> **Note:** Running real Fireworks training requires an account with training quota
+> (Tier 2 / credits). Without the SDK or an API key, `FireworksTrainer` runs in mock
+> mode so examples and tests work offline. Subclass `FireworksTrainer` and override
+> `format_example()` to handle custom data layouts, exactly as with `TinkerTrainer`.
+
+See the [Fireworks examples](examples/fireworks/) for basic and custom-trainer pipelines.
+
 ## Bespoke Curator Viewer
 The hosted curator viewer is a rich interface to visualize data -- and makes visually inspecting the data much easier.
 

--- a/examples/fireworks/basic_example.py
+++ b/examples/fireworks/basic_example.py
@@ -1,0 +1,126 @@
+"""Basic FireworksTrainer example: managed supervised fine-tuning on Fireworks AI.
+
+This example demonstrates:
+1. Creating training data in chat format
+2. Configuring FireworksTrainer (base model + LoRA settings)
+3. Running a managed supervised fine-tuning (SFT) job
+4. Deploying the fine-tuned model and sampling from it
+
+Fireworks runs fine-tuning as a managed, server-side job. Compared to the Tinker
+example, there is no client-side training loop: the dataset is uploaded, an SFT job
+is submitted, and Fireworks trains the model for you.
+
+Notes:
+- Fireworks requires at least 3 training examples.
+- Fine-tuned LoRA models cannot be served serverlessly, so `sample()` provisions an
+  on-demand deployment (which costs GPU time and takes a few minutes to spin up).
+  Call `trainer.close()` (or use the trainer as a context manager) to tear it down
+  when finished, so you don't leak a billable deployment.
+- Running real training requires a Fireworks account with training quota
+  (Tier 2 / credits). Without the SDK or an API key, this runs in mock mode.
+
+Usage:
+    # Mock mode (no API key / SDK required)
+    poetry run python examples/fireworks/basic_example.py
+
+    # Real fine-tuning (fireworks-ai is an optional add-on installed separately)
+    pip install fireworks-ai
+    export FIREWORKS_API_KEY="fw_..."
+    poetry run python examples/fireworks/basic_example.py
+"""
+
+from bespokelabs.curator import FireworksTrainer, FireworksTrainerConfig
+
+
+def get_training_data() -> list[dict]:
+    """Create sample chat training data with a distinctive, learnable style.
+
+    Each assistant answer ends with a fixed catchphrase. After fine-tuning, the
+    model should reproduce that catchphrase on unseen questions.
+    """
+    catchphrase = " Arrr, that's the bespoke truth, matey!"
+    facts = [
+        ("What is the capital of France?", "The capital of France is Paris."),
+        ("What is 2 + 2?", "2 + 2 equals 4."),
+        ("Who wrote Romeo and Juliet?", "Romeo and Juliet was written by William Shakespeare."),
+        ("What color is a clear daytime sky?", "A clear daytime sky is blue."),
+        ("Name a popular programming language.", "Python is a popular programming language."),
+        ("What is the largest planet in our solar system?", "Jupiter is the largest planet."),
+        ("How many continents are there?", "There are seven continents on Earth."),
+        ("What gas do plants absorb from the air?", "Plants absorb carbon dioxide."),
+        ("What is the boiling point of water in Celsius?", "Water boils at 100 degrees Celsius at sea level."),
+        ("Who painted the Mona Lisa?", "Leonardo da Vinci painted the Mona Lisa."),
+    ]
+    return [
+        {
+            "messages": [
+                {"role": "user", "content": question},
+                {"role": "assistant", "content": answer + catchphrase},
+            ]
+        }
+        for question, answer in facts
+    ]
+
+
+def main():
+    """Run the basic FireworksTrainer example."""
+    print("=" * 60)
+    print("Basic FireworksTrainer Example")
+    print("=" * 60)
+
+    print("\n[Step 1] Preparing training data...")
+    training_data = get_training_data()
+    print(f"  Training examples: {len(training_data)}")
+
+    print("\n[Step 2] Configuring FireworksTrainer...")
+    config = FireworksTrainerConfig(
+        base_model="qwen3-4b",  # smallest fine-tunable Fireworks model
+        # Fireworks packs examples into batches by token count, so a SMALL dataset can
+        # be a single batch (one optimizer step) per epoch. With few examples, use many
+        # epochs so the LoRA gets enough gradient steps to actually learn.
+        epochs=30,
+        lora_rank=16,
+        learning_rate=3e-4,  # or omit to let Fireworks auto-select
+        display_name="curator-basic-demo",
+        output_model="curator-basic-demo",
+    )
+    print(f"  Base Model: {config.qualified_base_model}")
+    print(f"  Epochs: {config.epochs}")
+    print(f"  LoRA Rank: {config.lora_rank}")
+
+    print("\n[Step 3] Running supervised fine-tuning...")
+    trainer = FireworksTrainer(config)
+    result = trainer.train(training_data)
+
+    print("\n" + "=" * 60)
+    print("Fine-tuning Complete!")
+    print("=" * 60)
+    print(f"  Output Model: {result.weights_name}")
+    print(f"  Samples Processed: {result.samples_processed}")
+    print(f"  Total Time: {result.total_time:.2f}s")
+    if result.loss_history:
+        print(f"  Final Loss: {result.final_loss:.4f}")
+    print(f"  Job: {result.metadata.get('job_url')}")
+
+    print("\n[Step 4] Sampling from the fine-tuned model...")
+    print("  (this deploys the model on-demand; first call may take a few minutes)")
+    test_prompts = [
+        "What is the capital of Japan?",
+        "Who discovered gravity?",
+    ]
+    for prompt in test_prompts:
+        print(f"\n  User: {prompt}")
+        response = trainer.sample(prompt)
+        print(f"  Assistant: {response}")
+
+    print("\n[Step 5] Cleaning up the deployment...")
+    trainer.close()
+
+    print("\n" + "=" * 60)
+    print("Example Complete!")
+    print("=" * 60)
+    return trainer
+
+
+if __name__ == "__main__":
+    trainer = main()

--- a/examples/fireworks/custom_trainer_example.py
+++ b/examples/fireworks/custom_trainer_example.py
@@ -1,0 +1,129 @@
+"""Custom FireworksTrainer example: subclass for custom data formatting.
+
+This example demonstrates:
+1. Subclassing FireworksTrainer to customize data formatting
+2. Using format_example() to convert raw data to chat training examples
+3. Working with non-standard data formats (instruction/response, Q&A with context)
+
+This pattern is useful when your data doesn't already use the standard "messages"
+format and needs custom conversion before fine-tuning.
+
+Usage:
+    poetry run python examples/fireworks/custom_trainer_example.py
+"""
+
+from bespokelabs.curator import FireworksTrainer, FireworksTrainerConfig
+from bespokelabs.curator.finetune.types import TrainingExample
+
+
+class InstructionTrainer(FireworksTrainer):
+    """Custom trainer for instruction-response datasets.
+
+    Converts data in {"instruction": ..., "response": ...} format to the chat
+    format required by Fireworks fine-tuning.
+    """
+
+    def format_example(self, row: dict) -> TrainingExample:
+        """Convert an instruction-response pair to chat format."""
+        return TrainingExample.from_dict_messages(
+            [
+                {"role": "system", "content": "You are a helpful assistant that follows instructions precisely."},
+                {"role": "user", "content": row["instruction"]},
+                {"role": "assistant", "content": row["response"]},
+            ]
+        )
+
+
+class QATrainer(FireworksTrainer):
+    """Custom trainer for question-answer datasets with optional context."""
+
+    def format_example(self, row: dict) -> TrainingExample:
+        """Convert a Q&A pair (with optional context) to chat format."""
+        if row.get("context"):
+            user_content = f"Context: {row['context']}\n\nQuestion: {row['question']}"
+        else:
+            user_content = row["question"]
+        return TrainingExample.from_dict_messages(
+            [
+                {"role": "system", "content": "You are a knowledgeable assistant. Answer accurately and concisely."},
+                {"role": "user", "content": user_content},
+                {"role": "assistant", "content": row["answer"]},
+            ]
+        )
+
+
+def get_instruction_data() -> list[dict]:
+    """Sample instruction-response dataset (Fireworks requires >= 3 examples)."""
+    return [
+        {
+            "instruction": "Summarize in one sentence: Machine learning lets systems learn from experience.",
+            "response": "Machine learning lets systems learn from experience automatically.",
+        },
+        {"instruction": "Convert to past tense: The cat jumps over the fence.", "response": "The cat jumped over the fence."},
+        {"instruction": "List two benefits of exercise.", "response": "1. Better cardiovascular health\n2. Improved mood"},
+        {"instruction": "Explain what an API is in one sentence.", "response": "An API is a contract that lets software components talk to each other."},
+    ]
+
+
+def get_qa_data() -> list[dict]:
+    """Sample Q&A dataset with optional context."""
+    return [
+        {"context": "Python was created by Guido van Rossum in 1991.", "question": "Who created Python?", "answer": "Guido van Rossum created Python."},
+        {"context": "The Great Wall of China is ~21,196 km long.", "question": "How long is the Great Wall?", "answer": "About 21,196 kilometers."},
+        {"question": "What is the capital of France?", "answer": "Paris is the capital of France."},
+        {
+            "context": "Photosynthesis converts sunlight into energy.",
+            "question": "What is photosynthesis?",
+            "answer": "The process by which plants convert sunlight into energy.",
+        },
+    ]
+
+
+def train_instruction_model():
+    """Train using the InstructionTrainer."""
+    print("\n" + "-" * 50)
+    print("Training InstructionTrainer")
+    print("-" * 50)
+    config = FireworksTrainerConfig(base_model="qwen3-4b", epochs=1, lora_rank=8, display_name="curator-instruction-demo")
+    data = get_instruction_data()
+    # `with` guarantees the on-demand inference deployment is torn down afterward.
+    with InstructionTrainer(config) as trainer:
+        print(f"Training on {len(data)} instruction-response pairs...")
+        result = trainer.train(data)
+        print(f"Output model: {result.weights_name}")
+        response = trainer.sample("Translate 'Hello, how are you?' to French.")
+        print(f"  Response: {response}")
+    return trainer
+
+
+def train_qa_model():
+    """Train using the QATrainer."""
+    print("\n" + "-" * 50)
+    print("Training QATrainer")
+    print("-" * 50)
+    config = FireworksTrainerConfig(base_model="qwen3-4b", epochs=1, lora_rank=8, display_name="curator-qa-demo")
+    data = get_qa_data()
+    with QATrainer(config) as trainer:
+        print(f"Training on {len(data)} Q&A pairs...")
+        result = trainer.train(data)
+        print(f"Output model: {result.weights_name}")
+        response = trainer.sample("Context: The Eiffel Tower opened in 1889.\n\nQuestion: When did the Eiffel Tower open?")
+        print(f"  Response: {response}")
+    return trainer
+
+
+def main():
+    """Run both custom trainer examples."""
+    print("=" * 60)
+    print("Custom FireworksTrainer Examples")
+    print("=" * 60)
+    instruction_trainer = train_instruction_model()
+    qa_trainer = train_qa_model()
+    print("\n" + "=" * 60)
+    print("Custom Trainer Examples Complete!")
+    print("=" * 60)
+    return instruction_trainer, qa_trainer
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bespokelabs/curator/__init__.py
+++ b/src/bespokelabs/curator/__init__.py
@@ -8,8 +8,8 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 from .code_executor.code_executor import CodeExecutor
-from .finetune.config import TinkerTrainerConfig
-from .finetune.trainer import TinkerTrainer
+from .finetune.config import FireworksTrainerConfig, TinkerTrainerConfig
+from .finetune.trainer import FireworksTrainer, TinkerTrainer
 from .llm.llm import LLM
 from .types import prompt as types
 from .utils import load_dataset, push_to_viewer
@@ -19,6 +19,8 @@ __all__ = [
     "CodeExecutor",
     "TinkerTrainer",
     "TinkerTrainerConfig",
+    "FireworksTrainer",
+    "FireworksTrainerConfig",
     "types",
     "push_to_viewer",
     "load_dataset",

--- a/src/bespokelabs/curator/finetune/__init__.py
+++ b/src/bespokelabs/curator/finetune/__init__.py
@@ -1,6 +1,7 @@
 """Fine-tuning module for curator.
 
-This module provides LoRA-based fine-tuning via the Tinker API.
+This module provides LoRA-based fine-tuning via the Tinker API (``TinkerTrainer``)
+and managed fine-tuning via the Fireworks AI API (``FireworksTrainer``).
 
 Example usage:
     ```python
@@ -47,10 +48,11 @@ Custom data formatting:
     ```
 """
 
-from bespokelabs.curator.finetune.config import AdamParams, LoRAConfig, TinkerTrainerConfig
+from bespokelabs.curator.finetune.config import AdamParams, FireworksTrainerConfig, LoRAConfig, TinkerTrainerConfig
 from bespokelabs.curator.finetune.data_formatter import DataFormatter
+from bespokelabs.curator.finetune.fireworks_data_formatter import FireworksDataFormatter
 from bespokelabs.curator.finetune.status_tracker import FinetuneStatusTracker
-from bespokelabs.curator.finetune.trainer import BaseTrainer, TinkerTrainer
+from bespokelabs.curator.finetune.trainer import BaseTrainer, FireworksTrainer, TinkerTrainer
 from bespokelabs.curator.finetune.types import (
     ChatMessage,
     CheckpointInfo,
@@ -63,10 +65,12 @@ from bespokelabs.curator.finetune.types import (
 __all__ = [
     # Config
     "TinkerTrainerConfig",
+    "FireworksTrainerConfig",
     "AdamParams",
     "LoRAConfig",
     # Trainers
     "TinkerTrainer",
+    "FireworksTrainer",
     "BaseTrainer",
     # Types
     "TrainingExample",
@@ -77,5 +81,6 @@ __all__ = [
     "CheckpointInfo",
     # Utilities
     "DataFormatter",
+    "FireworksDataFormatter",
     "FinetuneStatusTracker",
 ]

--- a/src/bespokelabs/curator/finetune/config.py
+++ b/src/bespokelabs/curator/finetune/config.py
@@ -1,9 +1,10 @@
 """Configuration models for fine-tuning."""
 
 import os
+import re
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AdamParams(BaseModel):
@@ -71,3 +72,105 @@ class TinkerTrainerConfig(BaseModel):
         if "api_key" not in data or data["api_key"] is None:
             data["api_key"] = os.environ.get("TINKER_API_KEY")
         super().__init__(**data)
+
+
+_VALID_LORA_RANKS = (1, 2, 4, 8, 16, 32)
+_RESOURCE_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+class FireworksTrainerConfig(BaseModel):
+    """Configuration for FireworksTrainer (Fireworks AI managed fine-tuning).
+
+    Fireworks runs supervised fine-tuning (SFT) as a managed, server-side job: a
+    chat-format JSONL dataset is uploaded, an SFT job is submitted against a base
+    model, and the result is a new (LoRA) model that is served via an on-demand
+    deployment. This mirrors :class:`TinkerTrainerConfig` but uses the parameters
+    that the Fireworks API actually exposes.
+
+    Attributes:
+        base_model: Base model to fine-tune. Either a short id (e.g. ``"qwen3-4b"``)
+            or a fully-qualified id (``"accounts/fireworks/models/qwen3-4b"``).
+        epochs: Number of training epochs (``examples * epochs`` must be <= 3,000,000).
+            Note: Fireworks packs examples into batches by token count, so a small
+            dataset may be a single batch (one optimizer step) per epoch. For tiny
+            datasets, use many epochs so the LoRA gets enough gradient steps to learn.
+        learning_rate: Learning rate. ``None`` lets Fireworks auto-select per base
+            model (recommended).
+        lora_rank: LoRA rank; must be a power of two up to 32. ``None`` requests a
+            full-parameter fine-tune instead of LoRA.
+        batch_size: Training batch size (tokens packed per step). ``None`` uses the
+            Fireworks default.
+        max_context_length: Maximum context length during training. ``None`` uses
+            the base-model default.
+        early_stop: Whether to enable early stopping.
+        output_model: Desired id for the resulting fine-tuned model. ``None`` lets
+            Fireworks derive it from the job id.
+        display_name: Human-readable job name; must match ``^[a-z0-9-]+$``.
+        api_key: Fireworks API key (defaults to the ``FIREWORKS_API_KEY`` env var).
+        account_id: Fireworks account id. ``None`` auto-discovers it from the key.
+        deployment_type: Deployment strategy used to serve the fine-tuned model for
+            inference. Fine-tuned LoRA models cannot be served serverlessly, so this
+            defaults to ``"on-demand"`` (Live Merge).
+        accelerator_type: Optional accelerator override for the inference deployment.
+        accelerator_count: Optional accelerator count for the inference deployment.
+        auto_deploy: If True, :meth:`FireworksTrainer.sample` provisions an on-demand
+            deployment automatically on first use. Always release it afterwards with
+            :meth:`FireworksTrainer.close` or by using the trainer as a context manager.
+        poll_interval_seconds: How often to poll the fine-tuning job for progress.
+        max_wait_seconds: Maximum time to wait for a fine-tuning job to complete.
+        inference_base_url: OpenAI-compatible base URL for inference.
+    """
+
+    base_model: str
+    epochs: int = Field(default=1, gt=0)
+    learning_rate: Optional[float] = Field(default=None, gt=0)
+    lora_rank: Optional[int] = Field(default=8)
+    batch_size: Optional[int] = Field(default=None, gt=0)
+    max_context_length: Optional[int] = Field(default=None, gt=0)
+    early_stop: Optional[bool] = None
+    output_model: Optional[str] = None
+    display_name: str = "curator-sft"
+    api_key: Optional[str] = None
+    account_id: Optional[str] = None
+
+    # Inference / deployment
+    deployment_type: str = "on-demand"
+    accelerator_type: Optional[str] = None
+    accelerator_count: Optional[int] = Field(default=None, gt=0)
+    auto_deploy: bool = True
+
+    # Polling / inference
+    poll_interval_seconds: int = Field(default=10, gt=0)
+    max_wait_seconds: int = Field(default=3600, gt=0)
+    inference_base_url: str = "https://api.fireworks.ai/inference/v1"
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("lora_rank")
+    @classmethod
+    def _validate_lora_rank(cls, value: Optional[int]) -> Optional[int]:
+        """Ensure lora_rank is a power of two up to 32 (Fireworks constraint)."""
+        if value is not None and value not in _VALID_LORA_RANKS:
+            raise ValueError(f"lora_rank must be one of {_VALID_LORA_RANKS} or None for full fine-tuning, got {value}")
+        return value
+
+    @field_validator("display_name")
+    @classmethod
+    def _validate_display_name(cls, value: str) -> str:
+        """Ensure display_name only contains lowercase letters, digits, and hyphens."""
+        if not _RESOURCE_NAME_RE.fullmatch(value):
+            raise ValueError(f"display_name must match ^[a-z0-9-]+$ (lowercase a-z, 0-9, hyphen), got {value!r}")
+        return value
+
+    def __init__(self, **data):
+        """Initialize config, loading API key from environment if not provided."""
+        if data.get("api_key") is None:
+            data["api_key"] = os.environ.get("FIREWORKS_API_KEY")
+        super().__init__(**data)
+
+    @property
+    def qualified_base_model(self) -> str:
+        """Return the fully-qualified base model id (``accounts/fireworks/models/...``)."""
+        if self.base_model.startswith("accounts/"):
+            return self.base_model
+        return f"accounts/fireworks/models/{self.base_model}"

--- a/src/bespokelabs/curator/finetune/fireworks_data_formatter.py
+++ b/src/bespokelabs/curator/finetune/fireworks_data_formatter.py
@@ -1,0 +1,56 @@
+"""Data formatter for converting datasets to the Fireworks chat JSONL format.
+
+Fireworks AI supervised fine-tuning expects an OpenAI-compatible chat-completion
+JSONL file: one JSON object per line of the form
+``{"messages": [{"role": ..., "content": ...}, ...]}``. This formatter reuses the
+shared :class:`DataFormatter` row -> :class:`TrainingExample` logic and adds the
+JSONL serialization that the Fireworks Dataset upload requires.
+"""
+
+import json
+from typing import Any, Dict, List
+
+from bespokelabs.curator.finetune.data_formatter import DataFormatter
+from bespokelabs.curator.finetune.types import TrainingExample
+
+
+class FireworksDataFormatter(DataFormatter):
+    """Converts curator datasets to the Fireworks chat JSONL format."""
+
+    def example_to_dict(self, example: TrainingExample) -> Dict[str, Any]:
+        """Convert a TrainingExample into a Fireworks chat-format dict.
+
+        Args:
+            example: The training example to convert.
+
+        Returns:
+            A dict ``{"messages": [{"role": ..., "content": ...}, ...]}``.
+        """
+        return {"messages": [{"role": msg.role, "content": msg.content} for msg in example.messages]}
+
+    def to_jsonl_lines(self, examples: List[TrainingExample]) -> List[str]:
+        """Serialize a list of examples to Fireworks chat JSONL lines.
+
+        Args:
+            examples: The training examples to serialize.
+
+        Returns:
+            A list of JSON strings, one per training example.
+        """
+        return [json.dumps(self.example_to_dict(example), ensure_ascii=False) for example in examples]
+
+    def write_jsonl(self, examples: List[TrainingExample], path: str) -> str:
+        """Write examples to a JSONL file in Fireworks chat format.
+
+        Args:
+            examples: The training examples to write.
+            path: Destination ``.jsonl`` file path.
+
+        Returns:
+            The path that was written.
+        """
+        lines = self.to_jsonl_lines(examples)
+        with open(path, "w", encoding="utf-8") as f:
+            for line in lines:
+                f.write(line + "\n")
+        return path

--- a/src/bespokelabs/curator/finetune/trainer/__init__.py
+++ b/src/bespokelabs/curator/finetune/trainer/__init__.py
@@ -1,6 +1,7 @@
 """Trainer module exports."""
 
 from bespokelabs.curator.finetune.trainer.base_trainer import BaseTrainer
+from bespokelabs.curator.finetune.trainer.fireworks_trainer import FireworksTrainer
 from bespokelabs.curator.finetune.trainer.tinker_trainer import TinkerTrainer
 
-__all__ = ["BaseTrainer", "TinkerTrainer"]
+__all__ = ["BaseTrainer", "TinkerTrainer", "FireworksTrainer"]

--- a/src/bespokelabs/curator/finetune/trainer/fireworks_trainer.py
+++ b/src/bespokelabs/curator/finetune/trainer/fireworks_trainer.py
@@ -1,0 +1,693 @@
+"""FireworksTrainer implementation for managed fine-tuning via the Fireworks AI API.
+
+Unlike :class:`TinkerTrainer`, which drives a low-level forward/backward training
+loop, Fireworks AI exposes *managed* fine-tuning: you upload a chat-format JSONL
+dataset, submit a supervised fine-tuning (SFT) job against a base model, poll the
+job until it completes, and then serve the resulting (LoRA) model from an on-demand
+deployment for inference. This trainer wraps that flow behind the same
+:class:`BaseTrainer` interface used by the rest of the ``finetune`` module.
+
+The official Fireworks "build SDK" (``pip install fireworks-ai``) is used for the
+control plane (dataset upload, job submission, deployment), and the OpenAI-compatible
+inference endpoint is used for sampling. When the SDK is not installed or no API key
+is available, the trainer runs in "mock mode" so examples and tests work offline.
+"""
+
+import inspect
+import os
+import re
+import tempfile
+import time
+from typing import Any, Dict, List, Optional
+
+from bespokelabs.curator.finetune.config import FireworksTrainerConfig
+from bespokelabs.curator.finetune.fireworks_data_formatter import FireworksDataFormatter
+from bespokelabs.curator.finetune.trainer.base_trainer import BaseTrainer
+from bespokelabs.curator.finetune.types import (
+    SamplingConfig,
+    TrainingExample,
+    TrainingResult,
+)
+from bespokelabs.curator.log import logger
+
+fireworks = None
+try:
+    import fireworks as _fireworks
+
+    required_fireworks_attrs = ("LLM", "Dataset")
+    if all(hasattr(_fireworks, attr) for attr in required_fireworks_attrs):
+        fireworks = _fireworks
+        FIREWORKS_AVAILABLE = True
+    else:
+        FIREWORKS_AVAILABLE = False
+except Exception:  # noqa: BLE001 - optional dep; never let a broken install break curator import
+    FIREWORKS_AVAILABLE = False
+
+
+# Terminal job states reported by the Fireworks API (normalized JobState names; a
+# leading "JOB_STATE_" prefix from the REST API is stripped before comparison).
+# Intermediate states (CREATING, RUNNING, VALIDATING, WRITING_RESULTS, PENDING,
+# EVALUATION, ROLLOUT, etc.) are not listed here and simply continue polling.
+# Default accelerator for on-demand inference deployments when none is configured.
+_DEFAULT_DEPLOY_ACCELERATOR = "NVIDIA_H100_80GB"
+
+# Fireworks JobState enum values (the SDK stores `_proto.state` as a raw int).
+_JOB_STATE_NAMES_BY_VALUE = {
+    0: "UNSPECIFIED",
+    1: "CREATING",
+    2: "RUNNING",
+    3: "COMPLETED",
+    4: "FAILED",
+    5: "CANCELLED",
+    6: "DELETING",
+    7: "WRITING_RESULTS",
+    8: "VALIDATING",
+    9: "ROLLOUT",
+    10: "EVALUATION",
+    11: "FAILED_CLEANING_UP",
+    12: "DELETING_CLEANING_UP",
+    13: "POLICY_UPDATE",
+    14: "PENDING",
+    15: "EXPIRED_CLEANING_UP",
+    16: "EXPIRED",
+    17: "CREATING_DEPENDENCIES",
+    18: "RE_QUEUEING",
+    19: "CREATING_INPUT_DATASET",
+}
+
+_COMPLETED_STATES = {"COMPLETED"}
+_FAILED_STATES = {
+    "FAILED",
+    "FAILED_CLEANING_UP",
+    "CANCELLED",
+    "DELETING",
+    "DELETING_CLEANING_UP",
+    "EXPIRED",
+    "EXPIRED_CLEANING_UP",
+}
+
+
+class FireworksTrainer(BaseTrainer):
+    """Trainer that uses the Fireworks AI managed fine-tuning API.
+
+    Example usage:
+        ```python
+        from bespokelabs.curator import FireworksTrainer, FireworksTrainerConfig
+        from datasets import Dataset
+
+        data = [
+            {"messages": [
+                {"role": "user", "content": "What is Python?"},
+                {"role": "assistant", "content": "Python is a programming language."}
+            ]},
+        ]
+        dataset = Dataset.from_list(data * 3)  # Fireworks requires >= 3 examples
+
+        config = FireworksTrainerConfig(
+            base_model="qwen3-4b",
+            epochs=1,
+            lora_rank=8,
+        )
+
+        trainer = FireworksTrainer(config)
+        result = trainer.train(dataset)        # uploads data, runs the SFT job
+        response = trainer.sample("Explain recursion")  # deploys + runs inference
+        trainer.close()                        # tears down the deployment (optional)
+        ```
+    """
+
+    def __init__(self, config: FireworksTrainerConfig):
+        """Initialize the FireworksTrainer.
+
+        Args:
+            config: FireworksTrainerConfig with training parameters.
+        """
+        self.config = config
+        self.data_formatter = FireworksDataFormatter()
+        self._output_model: Optional[str] = None
+        self._job_name: Optional[str] = None
+        self._job_url: Optional[str] = None
+        self._is_trained = False
+
+        # Populated when the SDK and an API key are available.
+        self._base_llm: Optional[Any] = None
+        self._account_id: Optional[str] = config.account_id
+        self._deployment_llm: Optional[Any] = None
+        self._deployment_ready = False
+
+        self._initialize_client()
+
+    @property
+    def is_mock(self) -> bool:
+        """Whether the trainer is running in mock mode (no SDK/key)."""
+        return self._base_llm is None
+
+    def _initialize_client(self) -> None:
+        """Initialize the Fireworks base-model handle used to launch SFT jobs."""
+        if not self.config.api_key:
+            logger.warning("No FIREWORKS_API_KEY provided. Running in mock mode.")
+            return
+
+        if not FIREWORKS_AVAILABLE:
+            logger.warning("Fireworks SDK not installed. Running in mock mode. Install with: pip install fireworks-ai")
+            return
+
+        try:
+            self._base_llm = self._build_base_llm()
+            if self._account_id is None:
+                self._account_id = self._base_llm._gateway.account_id()
+            logger.info(f"FireworksTrainer initialized for base model: {self.config.qualified_base_model}")
+            logger.info(f"Account: {self._account_id}, LoRA rank: {self.config.lora_rank}")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Fireworks client: {e}. Running in mock mode.")
+            self._base_llm = None
+
+    def _build_base_llm(self) -> Any:
+        """Construct a (non-provisioned) LLM handle for the base model.
+
+        The base model is only used to submit the SFT job, so the deployment is
+        never applied/provisioned. An ``id`` is still required by the SDK for the
+        on-demand deployment strategy.
+        """
+        deployment_id = self._sanitize_resource_name(f"curator-sft-{self.config.base_model}")
+        return fireworks.LLM(
+            model=self.config.qualified_base_model,
+            deployment_type="on-demand",
+            id=deployment_id,
+            api_key=self.config.api_key,
+        )
+
+    @staticmethod
+    def _sanitize_resource_name(name: str) -> str:
+        """Sanitize a string into a valid Fireworks resource name (``[a-z0-9-]``)."""
+        sanitized = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-")
+        return sanitized or "curator"
+
+    def _qualify_model_id(self, model_id: str) -> str:
+        """Expand a bare model id into a fully-qualified ``accounts/<acct>/models/<id>``.
+
+        The Fireworks API requires ``output_model`` to be a fully-qualified resource
+        name, so a bare id from the config is expanded using the discovered account id.
+        """
+        if model_id.startswith("accounts/"):
+            return model_id
+        account = self._account_id or "fireworks"
+        return f"accounts/{account}/models/{model_id}"
+
+    @staticmethod
+    def _get_supported_kwargs(callable_obj: Any, kwargs: Dict[str, Any]) -> tuple[Dict[str, Any], List[str]]:
+        """Filter keyword arguments to those accepted by the callable (forward-compat)."""
+        try:
+            parameters = inspect.signature(callable_obj).parameters
+        except (TypeError, ValueError):
+            return kwargs, []
+
+        if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+            return kwargs, []
+
+        supported_kwargs = {key: value for key, value in kwargs.items() if key in parameters}
+        ignored_kwargs = [key for key in kwargs if key not in supported_kwargs]
+        return supported_kwargs, ignored_kwargs
+
+    def format_example(self, row: Dict[str, Any]) -> TrainingExample:
+        """Format a dataset row into a TrainingExample.
+
+        Override this method to customize data formatting for your use case.
+
+        Args:
+            row: A dictionary containing the training data.
+
+        Returns:
+            TrainingExample with formatted messages.
+        """
+        return self.data_formatter.format_example(row)
+
+    @staticmethod
+    def _normalize_dataset(dataset: Any) -> List[Dict[str, Any]]:
+        """Normalize a HuggingFace Dataset / iterable into a list of rows."""
+        if hasattr(dataset, "to_list"):
+            return dataset.to_list()
+        if hasattr(dataset, "__iter__"):
+            return list(dataset)
+        return dataset
+
+    def train(self, dataset: Any) -> TrainingResult:
+        """Run a supervised fine-tuning job on the provided dataset.
+
+        Args:
+            dataset: HuggingFace Dataset or list of examples.
+
+        Returns:
+            TrainingResult with job metadata and the resulting model id.
+        """
+        start_time = time.time()
+        data_list = self._normalize_dataset(dataset)
+        num_examples = len(data_list)
+        examples = [self.format_example(row) for row in data_list]
+
+        if num_examples < 3:
+            logger.warning(f"Fireworks fine-tuning requires at least 3 examples; got {num_examples}. The job may be rejected.")
+
+        if self.is_mock:
+            return self._mock_train(num_examples, start_time)
+
+        # Reset all trained state up front so a failed (re)train leaves the trainer in a
+        # clean "not trained" state instead of silently retaining the previous run's
+        # model. Also tear down any deployment of the now-stale previous model.
+        self._is_trained = False
+        self._output_model = None
+        self._job_name = None
+        self._job_url = None
+        self.delete_deployment()
+
+        logger.info(f"Starting Fireworks SFT: {num_examples} examples, {self.config.epochs} epochs, base model {self.config.qualified_base_model}")
+
+        tmp_path = self._write_dataset_file(examples)
+        try:
+            dataset_obj = fireworks.Dataset.from_file(tmp_path)
+            dataset_obj.sync()
+            logger.info(f"Dataset uploaded: {dataset_obj.name}")
+
+            job = self._create_job(dataset_obj)
+            self._job_name = getattr(job, "name", None)
+            self._job_url = getattr(job, "url", None)
+            logger.info(f"Fine-tuning job submitted: {self._job_name} ({self._job_url})")
+
+            job = self._poll_job(job)
+            self._output_model = job.output_model
+            logger.info(f"Fine-tuning complete. Output model: {self._output_model}")
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        self._is_trained = True
+        total_time = time.time() - start_time
+        loss_history = self._maybe_fetch_loss_history(job)
+
+        return TrainingResult(
+            final_loss=loss_history[-1] if loss_history else 0.0,
+            total_steps=0,
+            total_epochs=self.config.epochs,
+            total_time=total_time,
+            tokens_processed=0,
+            samples_processed=num_examples,
+            loss_history=loss_history,
+            weights_name=self._output_model,
+            checkpoints=[],
+            metadata={
+                "provider": "fireworks",
+                "base_model": self.config.qualified_base_model,
+                "output_model": self._output_model,
+                "job_name": self._job_name,
+                "job_url": self._job_url,
+                "epochs": self.config.epochs,
+                "lora_rank": self.config.lora_rank,
+                "learning_rate": self.config.learning_rate,
+                "account_id": self._account_id,
+            },
+        )
+
+    def _write_dataset_file(self, examples: List[TrainingExample]) -> str:
+        """Write training examples to a ``.jsonl`` file with a stable, meaningful name.
+
+        Fireworks derives the dataset id from the file's contents and name, so using a
+        stable name (derived from the job's display name) lets repeated runs with the
+        same data deduplicate to a single uploaded dataset instead of creating orphans.
+        """
+        filename = f"curator-{self._sanitize_resource_name(self.config.display_name)}.jsonl"
+        path = os.path.join(tempfile.gettempdir(), filename)
+        return self.data_formatter.write_jsonl(examples, path)
+
+    def _create_job(self, dataset_obj: Any) -> Any:
+        """Submit the supervised fine-tuning job with the configured hyperparameters."""
+        candidate_kwargs = {
+            "epochs": self.config.epochs,
+            "learning_rate": self.config.learning_rate,
+            "lora_rank": self.config.lora_rank,
+            "batch_size": self.config.batch_size,
+            "max_context_length": self.config.max_context_length,
+            "early_stop": self.config.early_stop,
+            # output_model must be a fully-qualified resource name for the API.
+            "output_model": self._qualify_model_id(self.config.output_model) if self.config.output_model else None,
+        }
+        # Only forward parameters the user actually set.
+        candidate_kwargs = {key: value for key, value in candidate_kwargs.items() if value is not None}
+        supported_kwargs, ignored_kwargs = self._get_supported_kwargs(self._base_llm.create_supervised_fine_tuning_job, candidate_kwargs)
+        if ignored_kwargs:
+            logger.warning("Installed Fireworks SDK does not support SFT args %s; continuing without them.", ", ".join(ignored_kwargs))
+        return self._base_llm.create_supervised_fine_tuning_job(self.config.display_name, dataset_obj, **supported_kwargs)
+
+    @staticmethod
+    def _job_state_name(job: Any) -> str:
+        """Best-effort extraction of a readable job-state name from an SFT job.
+
+        Handles three representations of ``_proto.state``: an enum with ``.name``, a
+        raw integer (the SDK actually stores the enum field as an int — e.g. ``2`` for
+        RUNNING, ``3`` for COMPLETED), and a string. Returns ``"UNKNOWN"`` if the
+        state cannot be read. Note: a job's ``output_model`` is populated at *creation*
+        time (not completion), so completion is keyed on state only, never on it.
+        """
+        proto = getattr(job, "_proto", None)
+        state = getattr(proto, "state", None) if proto is not None else None
+        if state is None:
+            return "UNKNOWN"
+
+        name = getattr(state, "name", None)
+        if not name:
+            # Integer (or numeric-string) enum value -> map to a name.
+            try:
+                name = _JOB_STATE_NAMES_BY_VALUE[int(state)]
+            except (KeyError, ValueError, TypeError):
+                name = str(state)
+
+        # Normalize the REST-style "JOB_STATE_RUNNING" to the gRPC-style "RUNNING".
+        return name[len("JOB_STATE_") :] if name.startswith("JOB_STATE_") else name
+
+    def _poll_job(self, job: Any) -> Any:
+        """Poll a fine-tuning job until it completes, fails, or times out.
+
+        Completion is determined strictly by the job ``state`` (``COMPLETED``). If the
+        state cannot be read from this SDK version, defer to the SDK's own waiter.
+        """
+        start = time.time()
+        last_state: Optional[str] = None
+        while time.time() - start < self.config.max_wait_seconds:
+            state = self._job_state_name(job)
+            if state != last_state:
+                elapsed = int(time.time() - start)
+                logger.info(f"Fine-tuning job '{self.config.display_name}' state: {state} (elapsed {elapsed}s)")
+                last_state = state
+            if state in _COMPLETED_STATES:
+                return job
+            if state in _FAILED_STATES:
+                raise RuntimeError(f"Fireworks fine-tuning job '{self.config.display_name}' ended in state {state}")
+            if state == "UNKNOWN":
+                # This SDK build doesn't expose job state; fall back to its own waiter.
+                if hasattr(job, "wait_for_completion"):
+                    return job.wait_for_completion()
+                raise RuntimeError(f"Cannot determine state for job '{self.config.display_name}' and no wait_for_completion is available")
+            time.sleep(self.config.poll_interval_seconds)
+            refreshed = job.get()
+            if refreshed is None:
+                raise RuntimeError(f"Fireworks fine-tuning job '{self.config.display_name}' could not be found")
+            job = refreshed
+        logger.warning(
+            "Stopped waiting for fine-tuning job '%s' after %ss, but the job is STILL RUNNING server-side and "
+            "continues to incur charges. Cancel or monitor it at %s",
+            self.config.display_name,
+            self.config.max_wait_seconds,
+            self._job_url or "the Fireworks dashboard",
+        )
+        raise TimeoutError(
+            f"Fireworks fine-tuning job '{self.config.display_name}' did not finish within {self.config.max_wait_seconds}s (still running server-side)"
+        )
+
+    def _maybe_fetch_loss_history(self, job: Any) -> List[float]:
+        """Best-effort retrieval of training loss values from the job metrics file."""
+        proto = getattr(job, "_proto", None)
+        url = getattr(proto, "metrics_file_signed_url", None) if proto is not None else None
+        if not url:
+            return []
+        try:
+            import json
+
+            import requests
+
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            losses: List[float] = []
+            for line in response.text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                for key in ("loss", "train_loss", "training_loss"):
+                    if key in record and record[key] is not None:
+                        losses.append(float(record[key]))
+                        break
+            return losses
+        except Exception as e:  # noqa: BLE001 - metrics are best-effort only
+            logger.debug(f"Could not fetch loss history: {e}")
+            return []
+
+    def _mock_train(self, num_examples: int, start_time: float) -> TrainingResult:
+        """Produce a mock TrainingResult when running without the SDK or a key."""
+        import random
+
+        time.sleep(0.01)
+        self._is_trained = True
+        self._output_model = f"mock://accounts/{self._account_id or 'mock'}/models/{self.config.display_name}"
+        mock_loss = 2.5 - (random.random() * 0.5)
+        logger.info(f"Training (mock) complete. Output model: {self._output_model}")
+        return TrainingResult(
+            final_loss=mock_loss,
+            total_steps=0,
+            total_epochs=self.config.epochs,
+            total_time=time.time() - start_time,
+            tokens_processed=0,
+            samples_processed=num_examples,
+            loss_history=[mock_loss],
+            weights_name=self._output_model,
+            checkpoints=[],
+            metadata={"provider": "fireworks", "mock": True, "base_model": self.config.qualified_base_model},
+        )
+
+    def save_weights(self, name: str) -> str:
+        """Return the identifier of the fine-tuned model.
+
+        Fireworks persists the fine-tuned model server-side as part of the job, so
+        there is no separate save step; this returns the resulting model id.
+
+        Args:
+            name: Unused; present for interface compatibility with BaseTrainer.
+
+        Returns:
+            The fine-tuned model id (or a mock id when untrained).
+        """
+        if not self._is_trained:
+            logger.warning("Model has not been trained yet.")
+        return self._output_model or f"mock_weights_{name}"
+
+    def deploy(self, wait: bool = True) -> Any:
+        """Provision an on-demand deployment for the fine-tuned model.
+
+        Fine-tuned LoRA models cannot be served serverlessly, so an on-demand
+        (Live Merge) deployment is required before inference.
+
+        Args:
+            wait: Whether to block until the deployment is ready.
+
+        Returns:
+            The Fireworks LLM deployment handle, or a mock id in mock mode.
+        """
+        if not self._is_trained or not self._output_model:
+            logger.warning("Model has not been trained yet; cannot deploy.")
+            return None
+
+        if self.is_mock or self._output_model.startswith("mock://"):
+            self._deployment_ready = True
+            return self._output_model
+
+        if self._deployment_llm is not None and self._deployment_ready:
+            return self._deployment_llm
+
+        deployment_id = self._sanitize_resource_name(f"{self.config.display_name}-deploy")
+        # On-demand deployments require an accelerator type (unlike SFT jobs, where it
+        # must be auto-selected). Fall back to a sensible default if unset.
+        accelerator_type = self.config.accelerator_type or _DEFAULT_DEPLOY_ACCELERATOR
+        deploy_kwargs = {
+            "model": self._output_model,
+            "deployment_type": self.config.deployment_type,
+            "id": deployment_id,
+            "api_key": self.config.api_key,
+            "accelerator_type": accelerator_type,
+            "accelerator_count": self.config.accelerator_count,
+        }
+        deploy_kwargs = {key: value for key, value in deploy_kwargs.items() if value is not None}
+        supported_kwargs, _ = self._get_supported_kwargs(fireworks.LLM.__init__, deploy_kwargs)
+        logger.info(f"Deploying fine-tuned model {self._output_model} ({self.config.deployment_type})...")
+        self._deployment_llm = fireworks.LLM(**supported_kwargs)
+        self._deployment_llm.apply(wait=wait)
+        self._deployment_ready = True
+        logger.info(f"Deployment ready: {getattr(self._deployment_llm, 'deployment_url', '<unknown>')}")
+        return self._deployment_llm
+
+    def get_sampling_client(self) -> Any:
+        """Return the deployment handle used for sampling (deploying if needed)."""
+        if not self._is_trained:
+            logger.warning("Model has not been trained yet.")
+            return None
+        if self.is_mock:
+            return None
+        if not self._deployment_ready and self.config.auto_deploy:
+            self.deploy()
+        return self._deployment_llm
+
+    def sample(
+        self,
+        prompt: str,
+        sampling_config: Optional[SamplingConfig] = None,
+        system_prompt: Optional[str] = None,
+    ) -> str:
+        """Generate a sample from the fine-tuned model via the inference endpoint.
+
+        Args:
+            prompt: The user prompt.
+            sampling_config: Optional sampling configuration.
+            system_prompt: Optional system prompt.
+
+        Returns:
+            Generated text.
+        """
+        if sampling_config is None:
+            sampling_config = SamplingConfig()
+
+        messages: List[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        # Genuine mock mode (no SDK / no API key): return a clearly-fake response so
+        # examples and tests run offline.
+        if self.is_mock:
+            logger.info(f"Sampling (mock) with prompt: {prompt[:50]}...")
+            return f"[Mock response for: {prompt[:100]}...]"
+
+        # Real mode: a fine-tuned model is required. Never fabricate a mock response
+        # here — that would mask failed or skipped training. Run actual inference and
+        # let failures propagate.
+        if not self._is_trained or not self._output_model or self._output_model.startswith("mock://"):
+            raise RuntimeError("No fine-tuned model available for inference. Call train() and ensure it completed successfully before sampling.")
+        return self._sample_real(messages, sampling_config)
+
+    def _inference_model_id(self) -> str:
+        """Return the model id to use for inference, with LoRA deployment routing.
+
+        A fine-tuned LoRA adapter served on a dedicated deployment must be addressed
+        as ``<model>#<deployment>`` (the plain model id returns 404). When we created
+        the deployment, append its resource name; otherwise use the bare model id.
+        """
+        if self._deployment_llm is None:
+            return self._output_model
+        deployment_name = getattr(self._deployment_llm, "deployment_name", None)
+        if not deployment_name:
+            deployment_id = self._sanitize_resource_name(f"{self.config.display_name}-deploy")
+            deployment_name = f"accounts/{self._account_id}/deployments/{deployment_id}"
+        return f"{self._output_model}#{deployment_name}"
+
+    def _sample_real(self, messages: List[Dict[str, str]], sampling_config: SamplingConfig) -> str:
+        """Run inference against the deployed fine-tuned model (with scale-up retry)."""
+        from openai import OpenAI
+
+        if self.config.auto_deploy and not self._deployment_ready:
+            self.deploy()
+
+        client = OpenAI(base_url=self.config.inference_base_url, api_key=self.config.api_key)
+        request_kwargs: Dict[str, Any] = {
+            "model": self._inference_model_id(),
+            "messages": messages,
+            "max_tokens": sampling_config.max_tokens,
+            "temperature": sampling_config.temperature,
+            "top_p": sampling_config.top_p,
+        }
+        if sampling_config.stop_sequences:
+            request_kwargs["stop"] = sampling_config.stop_sequences
+        if sampling_config.top_k:
+            request_kwargs["extra_body"] = {"top_k": sampling_config.top_k}
+
+        max_attempts = 6
+        backoff = 5.0
+        last_error: Optional[Exception] = None
+        for attempt in range(max_attempts):
+            try:
+                response = client.chat.completions.create(**request_kwargs)
+                content = response.choices[0].message.content
+                return content.strip() if content else "[No response generated]"
+            except Exception as e:  # noqa: BLE001 - inspect message for scale-up signal
+                last_error = e
+                message = str(e).lower()
+                if "503" in message or "scal" in message or "not ready" in message:
+                    logger.info(f"Deployment scaling up; retrying in {backoff:.0f}s (attempt {attempt + 1}/{max_attempts})")
+                    time.sleep(backoff)
+                    backoff = min(backoff * 2, 60.0)
+                    continue
+                raise
+        raise RuntimeError(f"Inference failed after {max_attempts} attempts: {last_error}")
+
+    def delete_deployment(self) -> None:
+        """Tear down the on-demand inference deployment, if one was created.
+
+        Deletes the deployment *resource* directly via the gateway with
+        ``ignore_checks=True`` (so a deployment that recently served requests is still
+        removed — Fireworks otherwise blocks deletion for ~1 hour). This is more
+        reliable than ``LLM.delete_deployment``, which takes a PEFT-addon code path and
+        raises "is not a deployed model" for a dedicated on-demand deployment. Avoiding
+        a leaked, billable GPU deployment matters, so we fall back across methods.
+        """
+        if self._deployment_llm is not None and not self.is_mock:
+            if not self._gateway_delete_deployment():
+                self._llm_delete_deployment()
+        self._deployment_llm = None
+        self._deployment_ready = False
+
+    def _gateway_delete_deployment(self) -> bool:
+        """Delete the deployment resource directly via the gateway. Returns success."""
+        gateway = getattr(self._deployment_llm, "_gateway", None)
+        name = getattr(self._deployment_llm, "deployment_name", None) or getattr(self._deployment_llm, "deployment_id", None)
+        if gateway is None or name is None or not hasattr(gateway, "delete_deployment_sync"):
+            return False
+        try:
+            gateway.delete_deployment_sync(name, ignore_checks=True)
+            logger.info("Inference deployment deleted.")
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"gateway.delete_deployment_sync failed: {e}")
+            return False
+
+    def _llm_delete_deployment(self) -> None:
+        """Fallback: delete via the LLM handle (handles SDKs without ignore_checks)."""
+        try:
+            self._deployment_llm.delete_deployment(ignore_checks=True)
+            logger.info("Inference deployment deleted.")
+        except TypeError:
+            try:
+                self._deployment_llm.delete_deployment()
+                logger.info("Inference deployment deleted.")
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Failed to delete deployment: {e}")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Failed to delete deployment: {e}")
+
+    def close(self) -> None:
+        """Release resources, tearing down the on-demand inference deployment.
+
+        This always deletes the deployment (a billable GPU resource), so calling
+        ``close()`` — or using the trainer as a context manager — is the way to avoid
+        leaking it. If you want the deployment to persist, simply don't call ``close()``.
+        """
+        self.delete_deployment()
+
+    def __enter__(self) -> "FireworksTrainer":
+        """Enter a context that guarantees the inference deployment is torn down."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Always tear down the on-demand deployment on context exit (avoids cost leaks)."""
+        self.delete_deployment()
+        return False
+
+    @property
+    def output_model(self) -> Optional[str]:
+        """The fully-qualified id of the fine-tuned model (after training)."""
+        return self._output_model
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"FireworksTrainer(base_model={self.config.qualified_base_model}, "
+            f"epochs={self.config.epochs}, "
+            f"lora_rank={self.config.lora_rank}, "
+            f"trained={self._is_trained})"
+        )

--- a/tests/finetune/test_fireworks_config.py
+++ b/tests/finetune/test_fireworks_config.py
@@ -1,0 +1,99 @@
+"""Tests for FireworksTrainerConfig."""
+
+import pytest
+
+from bespokelabs.curator.finetune.config import FireworksTrainerConfig
+
+
+class TestFireworksTrainerConfig:
+    """Tests for FireworksTrainerConfig."""
+
+    def test_minimal_config(self):
+        """Test config with only required fields."""
+        config = FireworksTrainerConfig(base_model="qwen3-4b")
+        assert config.base_model == "qwen3-4b"
+        assert config.epochs == 1
+        assert config.lora_rank == 8
+        assert config.learning_rate is None
+        assert config.deployment_type == "on-demand"
+        assert config.inference_base_url == "https://api.fireworks.ai/inference/v1"
+
+    def test_qualified_base_model_short_id(self):
+        """Test short ids are expanded to fully-qualified resource names."""
+        config = FireworksTrainerConfig(base_model="qwen3-4b")
+        assert config.qualified_base_model == "accounts/fireworks/models/qwen3-4b"
+
+    def test_qualified_base_model_full_id(self):
+        """Test fully-qualified ids are left unchanged."""
+        config = FireworksTrainerConfig(base_model="accounts/fireworks/models/qwen3-8b")
+        assert config.qualified_base_model == "accounts/fireworks/models/qwen3-8b"
+
+    def test_full_config(self):
+        """Test config with all common fields."""
+        config = FireworksTrainerConfig(
+            base_model="qwen3-8b",
+            epochs=3,
+            learning_rate=1e-4,
+            lora_rank=16,
+            batch_size=32768,
+            max_context_length=4096,
+            early_stop=True,
+            output_model="my-model",
+            display_name="my-job",
+        )
+        assert config.epochs == 3
+        assert config.learning_rate == 1e-4
+        assert config.lora_rank == 16
+        assert config.batch_size == 32768
+        assert config.max_context_length == 4096
+        assert config.early_stop is True
+        assert config.output_model == "my-model"
+        assert config.display_name == "my-job"
+
+    @pytest.mark.parametrize("rank", [1, 2, 4, 8, 16, 32, None])
+    def test_valid_lora_ranks(self, rank):
+        """Test all valid LoRA ranks (powers of two up to 32, or None)."""
+        config = FireworksTrainerConfig(base_model="qwen3-4b", lora_rank=rank)
+        assert config.lora_rank == rank
+
+    @pytest.mark.parametrize("rank", [3, 7, 12, 64])
+    def test_invalid_lora_ranks(self, rank):
+        """Test invalid LoRA ranks are rejected."""
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", lora_rank=rank)
+
+    def test_invalid_display_name(self):
+        """Test display names with invalid characters are rejected."""
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", display_name="Bad Name")
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", display_name="UPPER")
+        with pytest.raises(ValueError):
+            # `$` alone would match before a trailing newline; fullmatch must reject it.
+            FireworksTrainerConfig(base_model="qwen3-4b", display_name="good-name\n")
+
+    def test_valid_display_name(self):
+        """Test valid display names are accepted."""
+        config = FireworksTrainerConfig(base_model="qwen3-4b", display_name="good-name-123")
+        assert config.display_name == "good-name-123"
+
+    def test_api_key_from_env(self, monkeypatch):
+        """Test API key loading from environment variable."""
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-test-key")
+        config = FireworksTrainerConfig(base_model="qwen3-4b")
+        assert config.api_key == "fw-test-key"
+
+    def test_api_key_explicit_overrides_env(self, monkeypatch):
+        """Test explicit API key overrides environment."""
+        monkeypatch.setenv("FIREWORKS_API_KEY", "env-key")
+        config = FireworksTrainerConfig(base_model="qwen3-4b", api_key="explicit-key")
+        assert config.api_key == "explicit-key"
+
+    def test_validation(self):
+        """Test numeric field validation."""
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", epochs=0)
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", batch_size=-1)
+        with pytest.raises(ValueError):
+            FireworksTrainerConfig(base_model="qwen3-4b", learning_rate=0)

--- a/tests/finetune/test_fireworks_trainer.py
+++ b/tests/finetune/test_fireworks_trainer.py
@@ -1,0 +1,385 @@
+"""Tests for FireworksTrainer."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from bespokelabs.curator.finetune.config import FireworksTrainerConfig
+from bespokelabs.curator.finetune.trainer import FireworksTrainer
+from bespokelabs.curator.finetune.trainer import fireworks_trainer as fireworks_trainer_module
+from bespokelabs.curator.finetune.types import TrainingExample, TrainingResult
+
+
+# ---------------------------------------------------------------------------
+# Fakes that emulate the Fireworks build SDK (fireworks.LLM / fireworks.Dataset)
+# ---------------------------------------------------------------------------
+class FakeProto:
+    """Stand-in for the protobuf job message."""
+
+    def __init__(self, state_name, output_model=None, metrics_url=None):
+        self.state = SimpleNamespace(name=state_name)
+        self.output_model = output_model
+        self.metrics_file_signed_url = metrics_url
+        self.create_time = None
+
+
+class FakeJob:
+    """Self-advancing fake fine-tuning job."""
+
+    def __init__(self, states, output_model, display_name="job"):
+        self.name = f"accounts/mahesh/supervisedFineTuningJobs/{display_name}"
+        self.url = "https://app.fireworks.ai/job"
+        self.display_name = display_name
+        self._states = list(states)
+        self._i = 0
+        self._final_output = output_model
+        initial = self._states[0]
+        self._proto = FakeProto(initial, output_model if initial == "COMPLETED" else None)
+
+    @property
+    def output_model(self):
+        return self._proto.output_model
+
+    def get(self):
+        self._i = min(self._i + 1, len(self._states) - 1)
+        name = self._states[self._i]
+        self._proto = FakeProto(name, self._final_output if name == "COMPLETED" else None)
+        return self
+
+
+class FakeDataset:
+    """Stand-in for fireworks.Dataset."""
+
+    last_path = None
+
+    def __init__(self, path=None):
+        self.name = "accounts/mahesh/datasets/fake-dataset"
+        self._path = path
+        self.synced = False
+
+    @classmethod
+    def from_file(cls, path):
+        cls.last_path = path
+        return cls(path)
+
+    def sync(self):
+        self.synced = True
+
+
+class FakeLLM:
+    """Stand-in for fireworks.LLM."""
+
+    last_init_kwargs = None
+    last_sft_kwargs = None
+
+    def __init__(self, **kwargs):
+        FakeLLM.last_init_kwargs = kwargs
+        self.kwargs = kwargs
+        self.model = kwargs.get("model")
+        self._gateway = SimpleNamespace(account_id=lambda: "mahesh", _api_key=kwargs.get("api_key"))
+        self.deployment_url = "https://app.fireworks.ai/deployment"
+        self.applied = False
+        self.deleted = False
+
+    def create_supervised_fine_tuning_job(self, display_name, dataset, **kwargs):
+        FakeLLM.last_sft_kwargs = kwargs
+        return FakeJob(["CREATING", "RUNNING", "COMPLETED"], "accounts/mahesh/models/curator-out", display_name)
+
+    def apply(self, wait=True):
+        self.applied = True
+        return self
+
+    def delete_deployment(self, ignore_checks=False, wait=True):
+        self.deleted = True
+
+
+def install_fake_sdk(monkeypatch, llm_cls=FakeLLM):
+    """Patch the trainer module to use the fake SDK."""
+    fake_fireworks = SimpleNamespace(LLM=llm_cls, Dataset=FakeDataset)
+    monkeypatch.setattr(fireworks_trainer_module, "FIREWORKS_AVAILABLE", True)
+    monkeypatch.setattr(fireworks_trainer_module, "fireworks", fake_fireworks)
+    # keep tests fast: never actually sleep while polling
+    monkeypatch.setattr(fireworks_trainer_module.time, "sleep", lambda *a, **k: None)
+
+
+@pytest.fixture
+def sample_data():
+    """Create sample training data."""
+    return [{"messages": [{"role": "user", "content": f"Q{i}"}, {"role": "assistant", "content": f"A{i}"}]} for i in range(4)]
+
+
+# ---------------------------------------------------------------------------
+# Mock mode (no SDK / no key)
+# ---------------------------------------------------------------------------
+class TestFireworksTrainerMockMode:
+    """Tests for FireworksTrainer running without the SDK or an API key."""
+
+    @pytest.fixture
+    def config(self, monkeypatch):
+        monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+        return FireworksTrainerConfig(base_model="qwen3-4b", epochs=1, lora_rank=8)
+
+    @pytest.fixture
+    def trainer(self, config):
+        return FireworksTrainer(config)
+
+    def test_initialization_is_mock(self, trainer):
+        assert trainer.is_mock is True
+        assert trainer._is_trained is False
+        assert trainer._output_model is None
+
+    def test_repr(self, trainer):
+        repr_str = repr(trainer)
+        assert "qwen3-4b" in repr_str
+        assert "lora_rank=8" in repr_str
+        assert "trained=False" in repr_str
+
+    def test_format_example(self, trainer, sample_data):
+        example = trainer.format_example(sample_data[0])
+        assert isinstance(example, TrainingExample)
+        assert len(example.messages) == 2
+        assert example.messages[0].role == "user"
+
+    def test_train_returns_result(self, trainer, sample_data):
+        result = trainer.train(sample_data)
+        assert isinstance(result, TrainingResult)
+        assert result.samples_processed == 4
+        assert result.total_epochs == 1
+        assert result.metadata["mock"] is True
+
+    def test_train_updates_state(self, trainer, sample_data):
+        assert trainer._is_trained is False
+        trainer.train(sample_data)
+        assert trainer._is_trained is True
+        assert trainer._output_model is not None
+
+    def test_sample_returns_str(self, trainer, sample_data):
+        trainer.train(sample_data)
+        response = trainer.sample("What is Python?")
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    def test_save_weights(self, trainer, sample_data):
+        trainer.train(sample_data)
+        weights = trainer.save_weights("unused")
+        assert weights == trainer._output_model
+
+
+# ---------------------------------------------------------------------------
+# Real mode against a faked SDK
+# ---------------------------------------------------------------------------
+class TestFireworksTrainerWithFakeSDK:
+    """Tests that exercise the real code paths against a faked Fireworks SDK."""
+
+    @pytest.fixture
+    def config(self):
+        return FireworksTrainerConfig(
+            base_model="qwen3-4b",
+            epochs=2,
+            lora_rank=8,
+            learning_rate=1e-4,
+            api_key="fw-test-key",
+            poll_interval_seconds=1,
+        )
+
+    def test_initialize_client_builds_base_llm(self, monkeypatch, config):
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        assert trainer.is_mock is False
+        assert trainer._account_id == "mahesh"
+        assert FakeLLM.last_init_kwargs["model"] == "accounts/fireworks/models/qwen3-4b"
+        assert FakeLLM.last_init_kwargs["deployment_type"] == "on-demand"
+
+    def test_train_full_flow(self, monkeypatch, config, sample_data):
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        result = trainer.train(sample_data)
+        assert trainer._is_trained is True
+        assert result.weights_name == "accounts/mahesh/models/curator-out"
+        assert result.samples_processed == 4
+        assert result.metadata["provider"] == "fireworks"
+        # dataset was written and uploaded
+        assert FakeDataset.last_path.endswith(".jsonl")
+        # hyperparameters were forwarded
+        assert FakeLLM.last_sft_kwargs["epochs"] == 2
+        assert FakeLLM.last_sft_kwargs["lora_rank"] == 8
+        assert FakeLLM.last_sft_kwargs["learning_rate"] == 1e-4
+
+    def test_train_omits_none_hyperparameters(self, monkeypatch, sample_data):
+        install_fake_sdk(monkeypatch)
+        config = FireworksTrainerConfig(base_model="qwen3-4b", api_key="k", learning_rate=None, batch_size=None, poll_interval_seconds=1)
+        trainer = FireworksTrainer(config)
+        trainer.train(sample_data)
+        assert "learning_rate" not in FakeLLM.last_sft_kwargs
+        assert "batch_size" not in FakeLLM.last_sft_kwargs
+
+    def test_create_job_filters_unsupported_kwargs(self, monkeypatch, sample_data):
+        """SFT args unsupported by an older SDK signature are dropped, not passed."""
+
+        class NarrowLLM(FakeLLM):
+            def create_supervised_fine_tuning_job(self, display_name, dataset, epochs=None, lora_rank=None):
+                NarrowLLM.last_sft_kwargs = {"epochs": epochs, "lora_rank": lora_rank}
+                return FakeJob(["COMPLETED"], "accounts/mahesh/models/curator-out", display_name)
+
+        install_fake_sdk(monkeypatch, llm_cls=NarrowLLM)
+        config = FireworksTrainerConfig(base_model="qwen3-4b", api_key="k", learning_rate=1e-4, batch_size=128, poll_interval_seconds=1)
+        trainer = FireworksTrainer(config)
+        result = trainer.train(sample_data)  # should not raise despite unsupported kwargs
+        assert result.weights_name == "accounts/mahesh/models/curator-out"
+
+    def test_job_state_name(self):
+        job = FakeJob(["RUNNING"], None)
+        assert FireworksTrainer._job_state_name(job) == "RUNNING"
+        completed = FakeJob(["COMPLETED"], "m")
+        completed._proto = FakeProto("COMPLETED", "m")
+        assert FireworksTrainer._job_state_name(completed) == "COMPLETED"
+
+    def test_job_state_name_handles_integer_and_prefixed_states(self):
+        """The SDK stores _proto.state as a raw int; REST uses JOB_STATE_ prefixes."""
+        # Raw integer enum values (the real SDK representation).
+        assert FireworksTrainer._job_state_name(SimpleNamespace(_proto=SimpleNamespace(state=2))) == "RUNNING"
+        assert FireworksTrainer._job_state_name(SimpleNamespace(_proto=SimpleNamespace(state=3))) == "COMPLETED"
+        assert FireworksTrainer._job_state_name(SimpleNamespace(_proto=SimpleNamespace(state=4))) == "FAILED"
+        # REST-style prefixed string is normalized.
+        assert FireworksTrainer._job_state_name(SimpleNamespace(_proto=SimpleNamespace(state=SimpleNamespace(name="JOB_STATE_COMPLETED")))) == "COMPLETED"
+        # Missing proto/state -> UNKNOWN.
+        assert FireworksTrainer._job_state_name(SimpleNamespace(_proto=None)) == "UNKNOWN"
+
+    def test_poll_job_completes_on_integer_state(self, monkeypatch, config):
+        """_poll_job must detect completion when state is the raw int 3 (COMPLETED)."""
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+
+        class IntStateJob:
+            def __init__(self, states):
+                self._states = states
+                self._i = 0
+                self._proto = SimpleNamespace(state=states[0])
+                self.display_name = "j"
+
+            @property
+            def output_model(self):
+                return "accounts/mahesh/models/m" if self._proto.state == 3 else None
+
+            def get(self):
+                self._i = min(self._i + 1, len(self._states) - 1)
+                self._proto = SimpleNamespace(state=self._states[self._i])
+                return self
+
+        done = trainer._poll_job(IntStateJob([1, 2, 3]))  # CREATING -> RUNNING -> COMPLETED
+        assert done.output_model == "accounts/mahesh/models/m"
+
+    def test_poll_job_raises_on_failure(self, monkeypatch, config):
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        failing = FakeJob(["RUNNING", "FAILED"], None)
+        with pytest.raises(RuntimeError):
+            trainer._poll_job(failing)
+
+    def test_sample_real_path(self, monkeypatch, config, sample_data):
+        install_fake_sdk(monkeypatch)
+
+        captured = {}
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                msg = SimpleNamespace(content="Paris is the capital of France.")
+                return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+        class FakeOpenAI:
+            def __init__(self, base_url=None, api_key=None):
+                captured["base_url"] = base_url
+                self.chat = SimpleNamespace(completions=FakeCompletions())
+
+        import openai
+
+        monkeypatch.setattr(openai, "OpenAI", FakeOpenAI)
+
+        trainer = FireworksTrainer(config)
+        trainer.train(sample_data)
+        response = trainer.sample("What is the capital of France?")
+        assert response == "Paris is the capital of France."
+        # LoRA inference must route through the dedicated deployment: model#deployment
+        assert captured["model"].startswith("accounts/mahesh/models/curator-out#")
+        assert "/deployments/" in captured["model"]
+        assert captured["base_url"] == config.inference_base_url
+        # deployment was provisioned for inference
+        assert trainer._deployment_ready is True
+
+    def test_deploy_and_delete(self, monkeypatch, config, sample_data):
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        trainer.train(sample_data)
+        deployment = trainer.deploy()
+        assert deployment.applied is True
+        trainer.delete_deployment()
+        assert trainer._deployment_ready is False
+
+    def test_close_always_tears_down_deployment(self, monkeypatch, config, sample_data):
+        """close() must release the billable deployment unconditionally (P1)."""
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        trainer.train(sample_data)
+        trainer.deploy()
+        assert trainer._deployment_ready is True
+        trainer.close()
+        assert trainer._deployment_ready is False
+        assert trainer._deployment_llm is None
+
+    def test_context_manager_tears_down_deployment(self, monkeypatch, config, sample_data):
+        """Using the trainer as a context manager tears down the deployment on exit."""
+        install_fake_sdk(monkeypatch)
+        with FireworksTrainer(config) as trainer:
+            trainer.train(sample_data)
+            trainer.deploy()
+            assert trainer._deployment_ready is True
+        assert trainer._deployment_ready is False
+        assert trainer._deployment_llm is None
+
+    def test_failed_retrain_resets_trained_state(self, monkeypatch, config, sample_data):
+        """A failed re-train must not leave stale trained-model state behind (P2)."""
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        trainer.train(sample_data)
+        assert trainer._is_trained is True
+        assert trainer._output_model == "accounts/mahesh/models/curator-out"
+
+        def boom(_dataset_obj):
+            raise RuntimeError("fireworks job failed")
+
+        monkeypatch.setattr(trainer, "_create_job", boom)
+        with pytest.raises(RuntimeError):
+            trainer.train(sample_data)
+        # The previous run's model must NOT be retained after a failed retrain.
+        assert trainer._is_trained is False
+        assert trainer._output_model is None
+
+    def test_sample_in_real_mode_without_training_raises(self, monkeypatch, config):
+        """In real mode, sampling without a trained model must raise, not fabricate (P3)."""
+        install_fake_sdk(monkeypatch)
+        trainer = FireworksTrainer(config)
+        assert trainer.is_mock is False
+        assert trainer._is_trained is False
+        with pytest.raises(RuntimeError):
+            trainer.sample("What is the capital of France?")
+
+
+class TestCustomFireworksTrainer:
+    """Tests for custom trainer subclasses."""
+
+    def test_custom_format_example(self):
+        class CustomTrainer(FireworksTrainer):
+            def format_example(self, row):
+                return TrainingExample.from_dict_messages(
+                    [
+                        {"role": "user", "content": row["question"]},
+                        {"role": "assistant", "content": row["answer"]},
+                    ]
+                )
+
+        config = FireworksTrainerConfig(base_model="qwen3-4b")
+        trainer = CustomTrainer(config)
+        example = trainer.format_example({"question": "What is Python?", "answer": "A language."})
+        assert len(example.messages) == 2
+        assert example.messages[0].content == "What is Python?"


### PR DESCRIPTION
## Summary

Adds a [Fireworks AI](https://docs.fireworks.ai/fine-tuning/fine-tuning-models) managed fine-tuning integration to the `finetune` module, behind the same `BaseTrainer` interface as `TinkerTrainer`. Unlike Tinker's client-side training loop, Fireworks runs SFT as a server-side job: the trainer uploads chat-format JSONL data, submits the job, polls to completion, and serves the resulting LoRA model from an on-demand deployment.

```python
from bespokelabs.curator import FireworksTrainer, FireworksTrainerConfig

config = FireworksTrainerConfig(base_model="qwen3-4b", epochs=2, lora_rank=8)
trainer = FireworksTrainer(config)
result = trainer.train(training_data)           # upload + SFT job + poll
response = trainer.sample("Explain recursion")  # deploys on demand
trainer.close()                                 # tears down the billable deployment
```

## What's included

- **`FireworksTrainerConfig`**: validated hyperparameters (LoRA rank must be a power of two ≤ 32, resource-name validation, API key from `FIREWORKS_API_KEY`), plus deployment and polling settings
- **`FireworksDataFormatter`**: serializes `TrainingExample`s to the OpenAI-compatible chat JSONL that Fireworks dataset upload expects
- **`FireworksTrainer`**: dataset upload, SFT job submission, state polling (handles enum/int/REST-prefixed job states), on-demand deployment with LoRA `model#deployment` routing, scale-up retry on inference, and guaranteed deployment teardown via `close()` or context manager
- **Mock mode** when the SDK (`pip install fireworks-ai`, optional) or API key is absent, so examples and tests run offline
- **Tests**: config validation + full trainer flow against a faked SDK (89 finetune tests pass)
- **Examples**: `examples/fireworks/` basic and custom-trainer (subclass `format_example`) pipelines
- **README**: usage section, What's New entry, and examples-table row

## Notes

- `fireworks-ai` is an optional dependency; the SDK import is guarded so a missing or conflicting `fireworks` package can never break `import bespokelabs.curator`
- Forward-compat kwarg filtering: SFT/deployment kwargs are checked against the installed SDK signature and dropped with a warning rather than crashing on older SDKs (verified against fireworks-ai 0.19.20)
- Deployment teardown deletes the deployment resource via the gateway with `ignore_checks=True`, falling back to `LLM.delete_deployment`, to avoid leaking billable GPU deployments

## Test plan

- [x] `pytest tests/finetune/` — 89 passed
- [x] `ruff check` / `ruff format` clean (pre-commit hooks pass)
- [x] Both examples run end-to-end in mock mode without SDK/key
- [x] SDK touchpoints (job-state enum values, gateway methods, kwarg names) verified against installed fireworks-ai 0.19.20
- [ ] Real end-to-end training run pending account training quota (Tier 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external API integration with billable GPU deployments and training jobs; mitigated by mock mode, explicit deployment teardown, and guarded optional SDK import.
> 
> **Overview**
> Adds **Fireworks AI managed SFT** alongside `TinkerTrainer`, using the same `BaseTrainer` pattern: upload chat JSONL, run a server-side job, poll to completion, then sample via an on-demand LoRA deployment.
> 
> New surface area includes **`FireworksTrainerConfig`** (validated LoRA rank, job names, `FIREWORKS_API_KEY`), **`FireworksDataFormatter`** for JSONL upload, and **`FireworksTrainer`** (optional `fireworks-ai` SDK, mock mode without key/SDK, job-state polling, `model#deployment` inference routing, deployment teardown via `close()` / context manager). Public exports, README section, `examples/fireworks/`, and finetune tests cover config and trainer flows with a faked SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3fed74fb74abf97e3003d9fd2de308584058fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->