### PR TITLE
Fix code execution on the local sandbox backend

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -52,4 +52,6 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          poetry run pytest --cov='bespokelabs' --cov-report=html --cov-fail-under=80  tests/
+          # Scope coverage to curator itself: bespokelabs-sandbox installs into the
+          # same bespokelabs.* namespace and would otherwise be measured too.
+          poetry run pytest --cov='bespokelabs.curator' --cov-report=html --cov-fail-under=80  tests/

--- a/src/bespokelabs/curator/code_executor/code_execution_backend/sandbox_backend.py
+++ b/src/bespokelabs/curator/code_executor/code_execution_backend/sandbox_backend.py
@@ -91,7 +91,16 @@ def _execute_in_sandbox(
             sb.write_file(f"{WORKSPACE_DIR}/program.py", code)
             sb.write_file(f"{WORKSPACE_DIR}/input.txt", code_input)
 
-            result = sb.execute_command("bash", args=["-c", f"cd {WORKSPACE_DIR} && timeout {timeout} python program.py < input.txt"])
+            # Host-style backends (local, ray) rebase absolute paths under
+            # $SANDBOX_ROOT, but their shell prelude does not wrap `cd`, so the
+            # workspace path must be rebased explicitly. Container backends
+            # (docker, e2b, ...) leave SANDBOX_ROOT unset and have a real
+            # /workspace. `python3` rather than `python`: stock macOS hosts
+            # (local backend) have no bare `python` binary.
+            result = sb.execute_command(
+                "bash",
+                args=["-c", f'cd "${{SANDBOX_ROOT:-}}{WORKSPACE_DIR}" && timeout {timeout} python3 program.py < input.txt'],
+            )
             files = _collect_sandbox_files(sb)
             stdout = result.stdout
             stderr = result.stderr


### PR DESCRIPTION
## Summary

CI on `main` has been red since #716 for **two independent reasons**, both fixed here:

### 1. Every CodeExecutor run on the default "local" backend fails

The backend runs `bash -c "cd /workspace && timeout N python program.py < input.txt"`. Host-style sandbox backends in bespokelabs-sandbox (local, ray) rebase absolute paths under a temp `$SANDBOX_ROOT` via a shell prelude that wraps common file utilities (`cat`, `ls`, `mkdir`, ...) — but **`cd` is not wrapped**, so the shell tries to enter the host's nonexistent `/workspace`:

```
bash: line 16: cd: /workspace: No such file or directory
```

The error is captured into the execution output, which is why `test_simple_code_execution_local` asserts against empty stdout.

**Fix:** `cd "${SANDBOX_ROOT:-}/workspace"` — host-style backends expand their sandbox root explicitly; container backends (docker, e2b, ...) leave `SANDBOX_ROOT` unset, so behavior there is unchanged. Also `python3` instead of `python`: stock macOS has no bare `python` binary, so the local backend failed on Macs even with the `cd` fix; `python3` is present on GitHub runners and in python docker images.

### 2. The 80% coverage gate now measures third-party code

`bespokelabs-sandbox` (required dep since #716) installs into the **same `bespokelabs.*` namespace package** that CI measures with `--cov=bespokelabs`. That pulled ~1,100 statements of sandbox backend code (docker/e2b/modal/ray/..., mostly unexercised in curator's CI) into the coverage denominator, dropping the total from 79.5% to ~72% and tripping `--cov-fail-under=80` even with all tests passing.

**Fix:** scope the workflow to `--cov=bespokelabs.curator` so the gate measures curator's own code again, as it effectively did before #716.

## Test plan

- [x] `pytest tests/code_executor/` with a fresh `CURATOR_CACHE_DIR` — 45 passed (previously failing test now passes)
- [x] Verified the exact failing command end-to-end via `_execute_in_sandbox` before/after
- [x] Verified `--cov=bespokelabs.curator` no longer measures `site-packages/bespokelabs/sandbox/*`
- [x] ruff check + format clean

Once this merges, re-running CI on open PRs (e.g. #719) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
