### PR TITLE
chore: bump 0.1.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bespokelabs-curator"
-version = "0.1.27"
+version = "0.1.28"
 description = "Bespoke Labs Curator"
 authors = ["Bespoke Labs <company@bespokelabs.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Release **bespokelabs-curator 0.1.28** — bumps `version` in `pyproject.toml` (`0.1.27` → `0.1.28`). The package version is read dynamically via `importlib.metadata`, so this is the only change needed.

## Changes since v0.1.27 (last release)
- be028ec Fix code execution on the local sandbox backend (#720)
- f060e1a Add FireworksTrainer for managed fine-tuning via Fireworks AI (#719)
- 8f26600 Use bespokelabs-sandbox to run code in sandboxes (#716)
- cb11a56 Clean up dead code (#715)
- fa05930 Fix simple_poem and use Sonnet 4.6 for multimodal testing (#714)
- 25a7eb6 Handle None cost values in batch request processor set_model_cost
- 99191e6 Fix poem finetuning example and Tinker compatibility (#712)
- 734cf7b chore: upgrade dependencies and add Tinker to What's New (#711)

## Release checklist
- [x] `poetry build` succeeds (sdist + wheel)
- [x] `twine check dist/*` passes
- [x] CI green on `main` HEAD
- [ ] Merge this PR
- [ ] Tag `v0.1.28` and `poetry publish` to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version change with no runtime or dependency edits in this PR.
> 
> **Overview**
> **Release bump only:** updates `[tool.poetry]` `version` in `pyproject.toml` from `0.1.27` to `0.1.28`. No source or dependency changes in this diff—the published version follows this field (e.g. via `importlib.metadata`).
> 
> Follow-up after merge: tag `v0.1.28` and publish to PyPI per the release checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ed37e66797780a87f60fc63fd9635dc6db5c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->