### PR TITLE
fix: honor system proxy env vars for Anthropic online requests

### DIFF
--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -315,7 +315,9 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
     def aiohttp_connector(self, tcp_limit: int) -> aiohttp.ClientSession:
         """Create an aiohttp connector with rate limiting."""
         connector = aiohttp.TCPConnector(limit=10 * tcp_limit)
-        return aiohttp.ClientSession(connector=connector)
+        # trust_env=True makes aiohttp honor HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY,
+        # which it otherwise ignores unlike requests/httpx (see issue #699).
+        return aiohttp.ClientSession(connector=connector, trust_env=True)
 
     async def process_requests_from_file(
         self,

--- a/tests/unittests/test_base_online_request_processor.py
+++ b/tests/unittests/test_base_online_request_processor.py
@@ -1,0 +1,20 @@
+import pytest
+
+from bespokelabs.curator.request_processor.online.anthropic_online_request_processor import AnthropicOnlineRequestProcessor
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_connector_trusts_env_proxy():
+    """Ensure the shared aiohttp session honors HTTP(S)_PROXY/ALL_PROXY env vars.
+
+    aiohttp.ClientSession ignores proxy environment variables unless trust_env=True
+    is set explicitly, unlike requests/httpx. Without it, requests (e.g. to the
+    Anthropic API) silently bypass any configured system proxy. See issue #699.
+
+    aiohttp_connector doesn't touch instance state, so we bypass __init__ (which
+    makes a live network call to fetch header-based rate limits) via object.__new__.
+    """
+    processor = object.__new__(AnthropicOnlineRequestProcessor)
+
+    async with processor.aiohttp_connector(tcp_limit=1) as session:
+        assert session.trust_env is True


### PR DESCRIPTION
## Summary

Fixes #699 — Anthropic client fails to use system proxy.

Curator's online (non-batch) request path doesn't actually call the `anthropic` SDK client — `AnthropicOnlineRequestProcessor.call_single_request` posts directly to the Anthropic REST endpoint using the shared `aiohttp.ClientSession` created in `BaseOnlineRequestProcessor.aiohttp_connector`. That session was constructed without `trust_env=True`.

Unlike `requests`/`httpx`, `aiohttp.ClientSession` does **not** read `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` env vars unless `trust_env=True` is explicitly passed. Without it, aiohttp always connects directly, bypassing any configured system/corporate proxy — exactly what's reported in #699.

This PR sets `trust_env=True` on that shared session. Since `aiohttp_connector` is used by all online request processors (not just Anthropic), this also fixes the same class of bug for other providers that go through the same path.

### Why not just bump the `anthropic` dependency (as proposed in #698)?

#698 proposed both `trust_env=True` *and* bumping `anthropic` to `>=0.54.0`. I checked current `main` and the dependency is already on `^0.84.0`, well past `0.54.0`, so that half is already moot. It also wouldn't have fixed this bug on its own: the online path never calls the `anthropic` SDK client, so an SDK version bump has no effect here. The batch path (`anthropic_batch_request_processor.py`) does use the real `AsyncAnthropic`/httpx-based client, which defaults `trust_env=True` already, so it was never actually affected by this bug.

### Verification

Added a unit test (`tests/unittests/test_base_online_request_processor.py`) asserting the session returned by `aiohttp_connector` has `trust_env=True`. Confirmed it fails on `main` and passes with this change.

I also verified the fix end-to-end with a local fake proxy: pointed `HTTPS_PROXY` at a local TCP listener and made a request to `api.anthropic.com` through an `aiohttp.ClientSession`.

- **Before the fix** (`trust_env=False`): request went straight to the real API, completely bypassing the local proxy.
- **After the fix** (`trust_env=True`): the local proxy received `CONNECT api.anthropic.com:443 HTTP/1.1` — aiohttp correctly tunneled through the configured proxy.

## Test plan

- [x] `pytest tests/unittests/test_base_online_request_processor.py` passes with the fix, fails without it
- [x] Ran full `tests/unittests/` suite — no regressions (pre-existing failures needing live network/API-key access are unrelated to this change and present identically on `main`)
- [x] Manually verified proxying behavior with a local fake-proxy script (see description above)