### PR TITLE
chore: bump 0.1.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bespokelabs-curator"
-version = "0.1.28"
+version = "0.1.29"
 description = "Bespoke Labs Curator"
 authors = ["Bespoke Labs <company@bespokelabs.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Bumps `bespokelabs-curator` to **0.1.29** for a new PyPI release.

### Included since 0.1.28
- Add Mistral batch finish reasons (#717)
- Upgrade litellm to 1.83.7 (#722)
- Honor system proxy env vars for Anthropic online requests (#725)
- Add native Azure OpenAI batch backend (#727)

### Note on CI
The testing workflow will likely show red on this PR, but **only on the coverage gate** (`--cov-fail-under=80`), not tests. Tip of `main` runs `231 passed, 24 skipped` with total coverage `78.99%` (below the 80% gate). Coverage has been under the gate since #717; a version-only bump does not change it. No functional test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)