### PR TITLE
Return cached partial results after interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ for troubleshooting information.
 > So now if you run the same prompt again, you will get the same response, pretty much instantly.
 > You can delete the cache at `~/.cache/curator` or disable it with `export CURATOR_DISABLE_CACHE=true`.
 
+For long runs, you can opt into partial results after a keyboard interrupt:
+
+```python
+llm = curator.LLM(
+    model_name="gpt-4o-mini",
+    backend_params={"allow_partial_result_on_interrupt": True},
+)
+```
+
+If you press Ctrl+C, Curator returns the successful responses already written to cache and records unfinished requests in `failed_requests.jsonl`.
 
 > [!IMPORTANT]
 > Make sure to set your API keys as environment variables for the model you are calling. For example running `export OPENAI_API_KEY=sk-...` and `export ANTHROPIC_API_KEY=ant-...` will allow you to run the previous two examples. A full list of supported models and their associated environment variable names can be found [in the litellm docs](https://docs.litellm.ai/docs/providers).

--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -139,7 +139,21 @@ class BaseRequestProcessor(ABC):
                 raise ValueError(f"Model {self.config.model} does not support structured output, response_format: {self.prompt_formatter.response_format}")
         generic_request_files = self.create_request_files(dataset)
 
-        self.requests_to_responses(generic_request_files)
+        try:
+            self.requests_to_responses(generic_request_files)
+        except KeyboardInterrupt:
+            if not self.config.allow_partial_result_on_interrupt:
+                raise
+
+            logger.warning(
+                "Interrupted before all requests finished. Returning a partial dataset from cached successful responses. "
+                f"Unfinished requests will be written to {os.path.join(self.working_dir, 'failed_requests.jsonl')}."
+            )
+            return self.create_dataset_files(
+                parse_func_hash,
+                allow_incomplete_responses=True,
+            )
+
         return self.create_dataset_files(parse_func_hash)
 
     def _verify_existing_request_files(self, dataset: Optional["Dataset"]) -> List[int]:
@@ -422,11 +436,14 @@ class BaseRequestProcessor(ABC):
     def create_dataset_files(
         self,
         parse_func_hash: str,
+        allow_incomplete_responses: bool = False,
     ) -> "Dataset":
         """Creates dataset from response files.
 
         Args:
             parse_func_hash: Hash identifying the dataset version
+            allow_incomplete_responses: Whether to build a dataset when some requests
+                do not have responses yet.
 
         Returns:
             Dataset containing processed responses
@@ -502,7 +519,7 @@ class BaseRequestProcessor(ABC):
 
             if failed_responses_count > 0:
                 logger.warning(f"{failed_responses_count} requests failed.")
-                if self.config.require_all_responses:
+                if self.config.require_all_responses and not allow_incomplete_responses:
                     os.remove(dataset_file)
                     raise ValueError(f"Some requests failed and require_all_responses is True. {error_sample_msg}")
             # Create a file with all failed requests
@@ -547,7 +564,7 @@ class BaseRequestProcessor(ABC):
                     f"{n_requests - total_responses_count} requests do not have responses. "
                     f"n_requests is {n_requests} and n_responses is {total_responses_count}"
                 )
-                if self.config.require_all_responses:
+                if self.config.require_all_responses and not allow_incomplete_responses:
                     os.remove(dataset_file)
                     raise ValueError("Some requests do not have responses and require_all_responses is True.")
 

--- a/src/bespokelabs/curator/request_processor/config.py
+++ b/src/bespokelabs/curator/request_processor/config.py
@@ -16,6 +16,7 @@ class RequestProcessorConfig(BaseModel):
         max_retries: Maximum number of retry attempts for failed requests
         request_timeout: Timeout in seconds for each request
         require_all_responses: Whether to require successful responses for all requests
+        allow_partial_result_on_interrupt: Whether to return cached successful responses after a keyboard interrupt.
         generation_params: Dictionary of model-specific generation parameters
         api_key: Optional API key for authentication
         in_mtok_cost: Optional cost per million input tokens
@@ -28,6 +29,7 @@ class RequestProcessorConfig(BaseModel):
     max_retries: int = Field(default=10, ge=0)
     request_timeout: int = Field(default=10 * 60, gt=0)
     require_all_responses: bool = Field(default=True)
+    allow_partial_result_on_interrupt: bool = False
     generation_params: dict = Field(default_factory=dict)
     return_completions_object: bool = False
     api_key: str | None = None
@@ -151,6 +153,7 @@ class BaseBackendParams(t.TypedDict, total=False):
     max_retries: t.Optional[int]
     request_timeout: t.Optional[int]
     require_all_responses: t.Optional[bool]
+    allow_partial_result_on_interrupt: t.Optional[bool]
 
 
 class OnlineBackendParams(BaseBackendParams, total=False):

--- a/tests/unittests/test_partial_result_interrupt.py
+++ b/tests/unittests/test_partial_result_interrupt.py
@@ -1,0 +1,101 @@
+import datetime
+import json
+import os
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+
+from bespokelabs.curator.request_processor.base_request_processor import BaseRequestProcessor
+from bespokelabs.curator.request_processor.config import RequestProcessorConfig
+from bespokelabs.curator.types.generic_request import GenericRequest
+from bespokelabs.curator.types.generic_response import GenericResponse
+
+
+class _PromptFormatter:
+    response_format = None
+
+    def response_to_response_format(self, response):
+        return response
+
+    def parse_func(self, row, response):
+        return {"prompt": row["prompt"], "answer": response}
+
+
+class _InterruptingProcessor(BaseRequestProcessor):
+    @property
+    def backend(self) -> str:
+        return "test"
+
+    def validate_config(self):
+        pass
+
+    def create_request_files(self, dataset):
+        request_file = os.path.join(self.working_dir, "requests_0.jsonl")
+        with open(request_file, "w") as f:
+            for idx, row in enumerate(dataset):
+                request = GenericRequest(
+                    model=self.config.model,
+                    messages=[{"role": "user", "content": row["prompt"]}],
+                    original_row=row,
+                    original_row_idx=idx,
+                )
+                f.write(request.model_dump_json() + "\n")
+        return [request_file]
+
+    def requests_to_responses(self, generic_request_files):
+        request = GenericRequest(
+            model=self.config.model,
+            messages=[{"role": "user", "content": "first"}],
+            original_row={"prompt": "first"},
+            original_row_idx=0,
+        )
+        response = GenericResponse(
+            response_message="done",
+            raw_response={},
+            raw_request={},
+            generic_request=request,
+            created_at=datetime.datetime.now(),
+            finished_at=datetime.datetime.now(),
+        )
+        response_file = os.path.join(self.working_dir, "responses_0.jsonl")
+        with open(response_file, "w") as f:
+            f.write(json.dumps(response.model_dump(), default=str) + "\n")
+        raise KeyboardInterrupt
+
+
+def test_interrupt_preserves_successful_responses_when_enabled(tmp_path: Path) -> None:
+    processor = _InterruptingProcessor(
+        RequestProcessorConfig(
+            model="test-model",
+            allow_partial_result_on_interrupt=True,
+        )
+    )
+
+    dataset = Dataset.from_list([{"prompt": "first"}, {"prompt": "second"}])
+    partial = processor.run(
+        dataset=dataset,
+        working_dir=str(tmp_path),
+        parse_func_hash="parse-hash",
+        prompt_formatter=_PromptFormatter(),
+    )
+
+    assert len(partial) == 1
+    assert partial[0] == {"prompt": "first", "answer": "done"}
+
+    failed_requests_path = tmp_path / "failed_requests.jsonl"
+    failed_requests = [json.loads(line) for line in failed_requests_path.read_text().splitlines()]
+    assert [request["original_row_idx"] for request in failed_requests] == [1]
+
+
+def test_interrupt_keeps_default_keyboard_interrupt_behavior(tmp_path: Path) -> None:
+    processor = _InterruptingProcessor(RequestProcessorConfig(model="test-model"))
+    dataset = Dataset.from_list([{"prompt": "first"}, {"prompt": "second"}])
+
+    with pytest.raises(KeyboardInterrupt):
+        processor.run(
+            dataset=dataset,
+            working_dir=str(tmp_path),
+            parse_func_hash="parse-hash",
+            prompt_formatter=_PromptFormatter(),
+        )


### PR DESCRIPTION
Closes #618

This adds an opt-in path for long Curator runs where Ctrl+C should not throw away useful completed work.

What changed:
- Adds `allow_partial_result_on_interrupt` to backend params.
- Keeps the old behavior by default. If the flag is not set, `KeyboardInterrupt` is re-raised.
- When the flag is set, Curator builds the output dataset from successful responses already written to cache.
- Unfinished requests are still written to `failed_requests.jsonl`, so the partial run is inspectable and resumable.
- Documents the flag in the README.

Why this matters:
For large online or batch-backed generation jobs, users often stop a run because the prompt is wrong, the provider is slow, or the dataset is larger than expected. The successful responses are already durable in Curator cache. This makes that path explicit instead of making users recover it by hand.

Local checks:
- `.venv/bin/python -m pytest tests/unittests/test_partial_result_interrupt.py tests/unittests/test_base_online_request_processor.py -q`
- `.venv/bin/ruff check src/bespokelabs/curator/request_processor/config.py src/bespokelabs/curator/request_processor/base_request_processor.py tests/unittests/test_partial_result_interrupt.py`
- `.venv/bin/ruff format --check src/bespokelabs/curator/request_processor/config.py src/bespokelabs/curator/request_processor/base_request_processor.py tests/unittests/test_partial_result_interrupt.py`