### PR TITLE
feat: reuse successful responses across cache runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,30 @@ for troubleshooting information.
 > So now if you run the same prompt again, you will get the same response, pretty much instantly.
 > You can delete the cache at `~/.cache/curator` or disable it with `export CURATOR_DISABLE_CACHE=true`.
 
+If you change generation parameters after a partial run, online processors can
+reuse successful responses from the previous cache while retrying only failed or
+unanswered requests with the new parameters:
+
+```python
+first_run = poet(topics, working_dir="my-cache")
+
+poet_with_more_tokens = Poet(
+    model_name="gpt-4o-mini",
+    generation_params={"max_tokens": 16384},
+)
+completed_run = poet_with_more_tokens(
+    topics,
+    working_dir="my-cache",
+    reuse_cache=first_run,
+)
+```
+
+`reuse_cache` also accepts a cache directory or a run fingerprint. For online
+text requests, Curator reuses only successful responses whose original input,
+rendered messages, model, and response schema match exactly. Generation
+parameters and row order may differ. Failed responses and non-matching prompts
+are submitted normally with the new parameters.
+
 
 > [!IMPORTANT]
 > Make sure to set your API keys as environment variables for the model you are calling. For example running `export OPENAI_API_KEY=sk-...` and `export ANTHROPIC_API_KEY=ant-...` will allow you to run the previous two examples. A full list of supported models and their associated environment variable names can be found [in the litellm docs](https://docs.litellm.ai/docs/providers).

--- a/src/bespokelabs/curator/llm/llm.py
+++ b/src/bespokelabs/curator/llm/llm.py
@@ -184,6 +184,35 @@ class LLM:
             logger.warning(f"Failed to load curator cached response: {e}")
             return None
 
+    @staticmethod
+    def _resolve_reuse_cache_dir(
+        reuse_cache: Union[str, Path, CuratorResponse],
+        curator_cache_dir: str,
+    ) -> Path:
+        """Resolve an explicit response cache used to seed a new run."""
+        if isinstance(reuse_cache, CuratorResponse):
+            if reuse_cache.cache_dir is None:
+                raise ValueError(
+                    "The supplied CuratorResponse does not have a cache directory."
+                )
+            candidate = Path(reuse_cache.cache_dir)
+        elif isinstance(reuse_cache, (str, Path)) and not isinstance(
+            reuse_cache, bool
+        ):
+            candidate = Path(reuse_cache).expanduser()
+            if not candidate.exists() and not candidate.is_absolute():
+                candidate = Path(curator_cache_dir) / candidate
+        else:
+            raise TypeError(
+                "reuse_cache must be a CuratorResponse, cache directory, "
+                "or run fingerprint."
+            )
+
+        candidate = candidate.resolve()
+        if not candidate.is_dir():
+            raise ValueError(f"Reuse cache directory does not exist: {candidate}")
+        return candidate
+
     def __call__(
         self,
         dataset: Optional[Iterable | CuratorResponse] = None,
@@ -191,6 +220,7 @@ class LLM:
         batch_cancel: bool = False,
         batch_cancel_auto_confirm: bool = False,
         cache_dir: Optional[Union[str, Path]] = None,
+        reuse_cache: Optional[Union[str, Path, CuratorResponse]] = None,
     ) -> CuratorResponse:
         """Apply structured completions in parallel to a dataset using specified model and prompts.
 
@@ -200,6 +230,9 @@ class LLM:
             batch_cancel (bool): Whether to cancel the batch if it is running
             batch_cancel_auto_confirm (bool): Whether we should automatically run batch cancellation without explicit user confirmation (for testing)
             cache_dir: Directory to cache results
+            reuse_cache: Previous CuratorResponse, cache directory, or run
+                fingerprint whose successful exact request matches should be
+                reused. Generation parameters may differ.
 
         Returns:
             CuratorResponse: A response object containing the dataset, failed requests, and various statistics
@@ -217,6 +250,12 @@ class LLM:
             )
         else:
             curator_cache_dir = working_dir
+
+        reuse_cache_dir = (
+            self._resolve_reuse_cache_dir(reuse_cache, curator_cache_dir)
+            if reuse_cache is not None
+            else None
+        )
 
         disable_cache = os.getenv("CURATOR_DISABLE_CACHE", "").lower() in ["true", "1"]
         fingerprint = self._hash_fingerprint(dataset_hash, disable_cache)
@@ -278,6 +317,7 @@ class LLM:
             working_dir=run_cache_dir,
             parse_func_hash=parse_func_hash,
             prompt_formatter=self.prompt_formatter,
+            reuse_cache_dir=str(reuse_cache_dir) if reuse_cache_dir else None,
         )
         viewer_url = self._request_processor.viewer_client.curator_viewer_url
 

--- a/src/bespokelabs/curator/request_processor/base_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/base_request_processor.py
@@ -22,6 +22,7 @@ from bespokelabs.curator.file_utilities import count_lines
 from bespokelabs.curator.hf_card_template import HUGGINGFACE_CARD_TEMPLATE
 from bespokelabs.curator.llm.prompt_formatter import PromptFormatter
 from bespokelabs.curator.log import logger
+from bespokelabs.curator.request_processor.cache import reuse_cached_responses
 from bespokelabs.curator.request_processor.config import BatchRequestProcessorConfig, RequestProcessorConfig
 from bespokelabs.curator.request_processor.event_loop import run_in_event_loop
 from bespokelabs.curator.types.generic_response import GenericResponse
@@ -106,6 +107,7 @@ class BaseRequestProcessor(ABC):
         working_dir: str,
         parse_func_hash: str,
         prompt_formatter: PromptFormatter,
+        reuse_cache_dir: str | None = None,
     ) -> "Dataset":
         """Uses the API to completing the specific map by calling the LLM.
 
@@ -114,6 +116,8 @@ class BaseRequestProcessor(ABC):
             working_dir: Working directory to save files (requests.jsonl, responses.jsonl, dataset.arrow)
             parse_func_hash: Hash of the parse function for caching
             prompt_formatter: Formatter for generating prompts from dataset rows
+            reuse_cache_dir: Previous run directory whose successful exact
+                request matches should seed this run
 
         Returns:
             Dataset: Completed dataset with LLM responses
@@ -139,8 +143,25 @@ class BaseRequestProcessor(ABC):
                 raise ValueError(f"Model {self.config.model} does not support structured output, response_format: {self.prompt_formatter.response_format}")
         generic_request_files = self.create_request_files(dataset)
 
+        if reuse_cache_dir is not None:
+            if not self.supports_cache_reuse:
+                raise NotImplementedError(
+                    "Cross-run cache reuse is currently supported only by "
+                    "online request processors."
+                )
+            reuse_cached_responses(
+                reuse_cache_dir,
+                generic_request_files,
+                set(self.config.invalid_finish_reasons),
+            )
+
         self.requests_to_responses(generic_request_files)
         return self.create_dataset_files(parse_func_hash)
+
+    @property
+    def supports_cache_reuse(self) -> bool:
+        """Whether this processor can resume from seeded response files."""
+        return False
 
     def _verify_existing_request_files(self, dataset: Optional["Dataset"]) -> List[int]:
         """Verify integrity of the cache and identify files needing regeneration.

--- a/src/bespokelabs/curator/request_processor/cache.py
+++ b/src/bespokelabs/curator/request_processor/cache.py
@@ -1,0 +1,155 @@
+"""Utilities for safely reusing successful responses from another Curator run."""
+
+import glob
+import json
+import os
+from collections import defaultdict, deque
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from bespokelabs.curator.log import logger
+from bespokelabs.curator.types.generic_request import GenericRequest
+from bespokelabs.curator.types.generic_response import GenericResponse
+
+
+def _request_identity(request: GenericRequest) -> str:
+    """Return the generation-parameter-independent identity of a request."""
+    request_data = request.model_dump(
+        mode="json",
+        exclude={"generation_params", "original_row_idx"},
+    )
+    original_row = request_data.get("original_row")
+    if isinstance(original_row, dict):
+        # Curator reserves this column for per-row generation controls.
+        original_row.pop("generation_params", None)
+    return json.dumps(
+        request_data,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _successful_cached_responses(
+    cache_dir: Path,
+    invalid_finish_reasons: set[str],
+) -> dict[str, deque[GenericResponse]]:
+    responses_by_request = defaultdict(deque)
+    for response_file in sorted(glob.glob(str(cache_dir / "responses_*.jsonl"))):
+        with open(response_file, encoding="utf-8") as source:
+            for line in source:
+                try:
+                    response = GenericResponse.model_validate_json(line)
+                except (json.JSONDecodeError, ValidationError):
+                    continue
+                if (
+                    response.response_errors
+                    or response.response_message is None
+                    or response.finish_reason in invalid_finish_reasons
+                ):
+                    continue
+                identity = _request_identity(response.generic_request)
+                responses_by_request[identity].append(response)
+    return responses_by_request
+
+
+def _completed_request_ids(response_file: Path) -> set[int]:
+    completed = set()
+    if not response_file.exists():
+        return completed
+    with open(response_file, encoding="utf-8") as existing:
+        for line in existing:
+            try:
+                response = GenericResponse.model_validate_json(line)
+            except (json.JSONDecodeError, ValidationError):
+                continue
+            if not response.response_errors and response.response_message is not None:
+                completed.add(response.generic_request.original_row_idx)
+    return completed
+
+
+def reuse_cached_responses(
+    source_cache_dir: str | Path,
+    request_files: list[str],
+    invalid_finish_reasons: set[str] | None = None,
+) -> int:
+    """Seed a new run with exact request matches from a previous cache.
+
+    Generation parameters and row positions may differ. The model, rendered
+    messages, response schema, multimodal flag, and original input row must
+    otherwise match exactly. Failed responses are never reused.
+
+    Args:
+        source_cache_dir: Previous Curator run directory containing response
+            JSONL files.
+        request_files: Newly generated request JSONL files for the current run.
+        invalid_finish_reasons: Finish reasons that must be retried rather than
+            reused.
+
+    Returns:
+        Number of successful responses copied into the current run.
+    """
+    source_cache_dir = Path(source_cache_dir).expanduser().resolve()
+    if not source_cache_dir.is_dir():
+        raise ValueError(
+            f"Reuse cache directory does not exist: {source_cache_dir}"
+        )
+    if not request_files:
+        return 0
+
+    destination_dir = Path(request_files[0]).resolve().parent
+    if source_cache_dir == destination_dir:
+        return 0
+
+    cached_responses = _successful_cached_responses(
+        source_cache_dir,
+        invalid_finish_reasons or set(),
+    )
+    reused_count = 0
+
+    for request_file_name in request_files:
+        request_file = Path(request_file_name)
+        response_file = Path(
+            str(request_file).replace("requests_", "responses_")
+        )
+        completed_ids = _completed_request_ids(response_file)
+        responses_to_append = []
+
+        with open(request_file, encoding="utf-8") as requests:
+            for line in requests:
+                try:
+                    current_request = GenericRequest.model_validate_json(line)
+                except (json.JSONDecodeError, ValidationError):
+                    continue
+                if current_request.original_row_idx in completed_ids:
+                    continue
+
+                matching = cached_responses.get(
+                    _request_identity(current_request)
+                )
+                if not matching:
+                    continue
+
+                reused_response = matching.popleft().model_copy(deep=True)
+                source_generation_params = dict(
+                    reused_response.generic_request.generation_params
+                )
+                reused_response.generic_request = current_request.model_copy(deep=True)
+                reused_response.generic_request.generation_params = (
+                    source_generation_params
+                )
+                reused_response.parsed_response_message = None
+                responses_to_append.append(reused_response.model_dump_json())
+                completed_ids.add(current_request.original_row_idx)
+                reused_count += 1
+
+        if responses_to_append:
+            os.makedirs(response_file.parent, exist_ok=True)
+            with open(response_file, "a", encoding="utf-8") as destination:
+                destination.write("\n".join(responses_to_append) + "\n")
+
+    logger.info(
+        f"Reused {reused_count} successful responses from {source_cache_dir}"
+    )
+    return reused_count

--- a/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
+++ b/src/bespokelabs/curator/request_processor/online/base_online_request_processor.py
@@ -93,6 +93,11 @@ class BaseOnlineRequestProcessor(BaseRequestProcessor, ABC):
         return "base"
 
     @property
+    def supports_cache_reuse(self) -> bool:
+        """Online processors skip request IDs already present in responses."""
+        return True
+
+    @property
     def compatible_provider(self) -> str:
         """Compatible provider property."""
         return "base"

--- a/tests/unittests/test_cache_reuse.py
+++ b/tests/unittests/test_cache_reuse.py
@@ -1,0 +1,206 @@
+import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from bespokelabs.curator.llm.llm import LLM
+from bespokelabs.curator.request_processor.cache import reuse_cached_responses
+from bespokelabs.curator.types.generic_request import GenericRequest
+from bespokelabs.curator.types.generic_response import GenericResponse
+
+
+def _request(
+    *,
+    idx: int,
+    question: str,
+    max_tokens: int,
+    prompt: str | None = None,
+) -> GenericRequest:
+    return GenericRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "user",
+                "content": prompt or question,
+            }
+        ],
+        response_format=None,
+        original_row={"question": question},
+        original_row_idx=idx,
+        generation_params={"max_tokens": max_tokens},
+    )
+
+
+def _response(
+    request: GenericRequest,
+    answer: str | None,
+    errors: list[str] | None = None,
+    finish_reason: str | None = None,
+) -> GenericResponse:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return GenericResponse(
+        response_message=answer,
+        response_errors=errors,
+        raw_response={},
+        raw_request={},
+        generic_request=request,
+        created_at=now,
+        finished_at=now,
+        finish_reason=finish_reason or ("stop" if not errors else "length"),
+    )
+
+
+def _write_jsonl(path: Path, rows) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as output:
+        for row in rows:
+            if isinstance(row, (GenericRequest, GenericResponse)):
+                output.write(row.model_dump_json() + "\n")
+            else:
+                output.write(json.dumps(row) + "\n")
+
+
+def test_reuse_cache_copies_only_successful_exact_request_matches(tmp_path):
+    source = tmp_path / "old-cache"
+    destination = tmp_path / "new-cache"
+
+    source_a = _request(
+        idx=0,
+        question="Question A",
+        max_tokens=8192,
+    )
+    source_b = _request(
+        idx=1,
+        question="Question B",
+        max_tokens=8192,
+    )
+    source_c = _request(
+        idx=2,
+        question="Question C",
+        max_tokens=8192,
+    )
+    _write_jsonl(
+        source / "responses_0.jsonl",
+        [
+            _response(source_a, "Answer A"),
+            _response(
+                source_b,
+                "Truncated answer B",
+                finish_reason="length",
+            ),
+            _response(source_c, "Answer C"),
+        ],
+    )
+
+    current_b = _request(
+        idx=0,
+        question="Question B",
+        max_tokens=16384,
+    )
+    current_c_changed_prompt = _request(
+        idx=1,
+        question="Question C",
+        max_tokens=16384,
+        prompt="A changed prompt for Question C",
+    )
+    current_a_reordered = _request(
+        idx=2,
+        question="Question A",
+        max_tokens=16384,
+    )
+    request_file = destination / "requests_0.jsonl"
+    _write_jsonl(
+        request_file,
+        [current_b, current_c_changed_prompt, current_a_reordered],
+    )
+
+    assert (
+        reuse_cached_responses(
+            source,
+            [str(request_file)],
+            {"length", "content_filter"},
+        )
+        == 1
+    )
+
+    reused_lines = (destination / "responses_0.jsonl").read_text(
+        encoding="utf-8"
+    ).splitlines()
+    assert len(reused_lines) == 1
+    reused = GenericResponse.model_validate_json(reused_lines[0])
+    assert reused.response_message == "Answer A"
+    assert reused.generic_request.original_row_idx == 2
+    assert reused.generic_request.generation_params == {"max_tokens": 8192}
+    assert reused.parsed_response_message is None
+
+    # Reapplying the same source is idempotent.
+    assert (
+        reuse_cached_responses(
+            source,
+            [str(request_file)],
+            {"length", "content_filter"},
+        )
+        == 0
+    )
+    assert (
+        len(
+            (destination / "responses_0.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+        == 1
+    )
+
+
+def test_reuse_cache_ignores_reserved_row_generation_params(tmp_path):
+    source = tmp_path / "old-cache"
+    destination = tmp_path / "new-cache"
+    source_request = _request(
+        idx=0,
+        question="Question A",
+        max_tokens=8192,
+    )
+    source_request.original_row["generation_params"] = json.dumps(
+        {"max_tokens": 8192}
+    )
+    current_request = _request(
+        idx=0,
+        question="Question A",
+        max_tokens=16384,
+    )
+    current_request.original_row["generation_params"] = json.dumps(
+        {"max_tokens": 16384}
+    )
+    _write_jsonl(
+        source / "responses_0.jsonl",
+        [_response(source_request, "Answer A")],
+    )
+    request_file = destination / "requests_0.jsonl"
+    _write_jsonl(request_file, [current_request])
+
+    assert reuse_cached_responses(source, [str(request_file)]) == 1
+
+
+@pytest.mark.parametrize(
+    "reuse_cache",
+    [True, 123, object()],
+)
+def test_reuse_cache_rejects_invalid_source_types(tmp_path, reuse_cache):
+    with pytest.raises(TypeError, match="reuse_cache"):
+        LLM._resolve_reuse_cache_dir(reuse_cache, str(tmp_path))
+
+
+def test_reuse_cache_resolves_run_fingerprint_from_working_dir(tmp_path):
+    source = tmp_path / "old-run-hash"
+    source.mkdir()
+
+    assert (
+        LLM._resolve_reuse_cache_dir("old-run-hash", str(tmp_path))
+        == source.resolve()
+    )
+
+
+def test_reuse_cache_rejects_missing_directory(tmp_path):
+    with pytest.raises(ValueError, match="does not exist"):
+        LLM._resolve_reuse_cache_dir("missing-run", str(tmp_path))


### PR DESCRIPTION
## Summary

- add an explicit `reuse_cache` argument accepting a previous `CuratorResponse`, cache directory, or run fingerprint
- seed a new online run only with successful responses whose model, rendered request, response schema, and original input match exactly
- ignore generation parameters and row order for matching, while preserving the parameters that actually produced a reused response
- retry truncated, failed, unanswered, and non-matching requests with the new generation parameters
- keep reuse opt-in and leave the existing generation-parameter-aware run fingerprint unchanged

## Safety

- malformed and errored cached responses are never reused
- configured invalid finish reasons such as `length` and `content_filter` are never reused
- changed prompts or response schemas do not match
- reuse is idempotent and currently limited to online text processors

## Tests

- `python -m pytest tests/unittests/test_cache_reuse.py -q` (7 passed)
- `python -m ruff check ...` (passed)
- `git diff --check` (passed)

Fixes #697